### PR TITLE
Fix overview screen float

### DIFF
--- a/src/main/resources/templates/dashboard/customers/create.html
+++ b/src/main/resources/templates/dashboard/customers/create.html
@@ -41,7 +41,7 @@
     </div>
     <div class="row content-wrapper">
         <div th:replace="/fragments/sidebar :: sidebar" class="col-xs-2"></div>
-        <div class="col-xs-10 main">
+        <div class="col-xs-9 main">
             <div class="page-header">
                 <h1><samp>Create customer</samp></h1>
             </div>

--- a/src/main/resources/templates/dashboard/customers/edit.html
+++ b/src/main/resources/templates/dashboard/customers/edit.html
@@ -41,7 +41,7 @@
     </div>
     <div class="row content-wrapper">
         <div th:replace="/fragments/sidebar :: sidebar" class="col-xs-2"></div>
-        <div class="col-xs-10 main">
+        <div class="col-xs-9 main">
             <div class="page-header">
                 <h1><samp>Edit customer</samp></h1>
             </div>

--- a/src/main/resources/templates/dashboard/customers/index.html
+++ b/src/main/resources/templates/dashboard/customers/index.html
@@ -38,7 +38,7 @@
     </div>
     <div class="row content-wrapper">
         <div th:replace="/fragments/sidebar :: sidebar" class="col-xs-2"></div>
-        <div class="col-xs-10 main">
+        <div class="col-xs-9 main">
             <div class="page-header">
                 <h1><samp>Customers</samp>
                     <a class="btn btn-primary btn-dashboard-header" th:href="@{create/}">Create new customer</a></h1>

--- a/src/main/resources/templates/dashboard/events/create.html
+++ b/src/main/resources/templates/dashboard/events/create.html
@@ -41,7 +41,7 @@
     </div>
     <div class="row content-wrapper">
         <div th:replace="/fragments/sidebar :: sidebar" class="col-xs-2"></div>
-        <div class="col-xs-10 main">
+        <div class="col-xs-9 main">
             <div class="page-header">
                 <h1><samp>Create event</samp></h1>
             </div>

--- a/src/main/resources/templates/dashboard/events/edit.html
+++ b/src/main/resources/templates/dashboard/events/edit.html
@@ -42,7 +42,7 @@
     </div>
     <div class="row content-wrapper">
         <div th:replace="/fragments/sidebar :: sidebar" class="col-xs-2"></div>
-        <div class="col-xs-10 main">
+        <div class="col-xs-9 main">
             <div class="page-header">
                 <h1><samp>Edit event</samp></h1>
             </div>

--- a/src/main/resources/templates/dashboard/events/index.html
+++ b/src/main/resources/templates/dashboard/events/index.html
@@ -38,7 +38,7 @@
     </div>
     <div class="row content-wrapper">
         <div th:replace="/fragments/sidebar :: sidebar" class="col-xs-2"></div>
-        <div class="col-xs-10 main">
+        <div class="col-xs-9 main">
             <div class="page-header">
                 <h1><samp>Events</samp><a class="btn btn-primary btn-dashboard-header" href="create/">Create new
                     event</a></h1>

--- a/src/main/resources/templates/dashboard/events/overview.html
+++ b/src/main/resources/templates/dashboard/events/overview.html
@@ -39,7 +39,7 @@
     <div class="row content-wrapper">
         <!--/*@thymesVar id="event" type="ch.wisv.events.core.model.event.Event"*/-->
         <div th:replace="/fragments/sidebar :: sidebar" class="col-xs-2"></div>
-        <div class="col-xs-10 main">
+        <div class="col-xs-9 main">
             <div class="page-header">
                 <h1><samp th:text="'Sold products for ' + ${event.getTitle()}"></samp></h1>
             </div>

--- a/src/main/resources/templates/dashboard/orders/edit.html
+++ b/src/main/resources/templates/dashboard/orders/edit.html
@@ -38,7 +38,7 @@
     </div>
     <div class="row content-wrapper">
         <div th:replace="/fragments/sidebar :: sidebar" class="col-xs-2"></div>
-        <div class="col-xs-10 main">
+        <div class="col-xs-9 main">
             <div class="page-header">
                 <h1><samp th:text="'Order #' + ${order.getId()}"></samp></h1>
             </div>

--- a/src/main/resources/templates/dashboard/orders/index.html
+++ b/src/main/resources/templates/dashboard/orders/index.html
@@ -38,7 +38,7 @@
     </div>
     <div class="row content-wrapper">
         <div th:replace="/fragments/sidebar :: sidebar" class="col-xs-2"></div>
-        <div class="col-xs-10 main">
+        <div class="col-xs-9 main">
             <div class="page-header">
                 <h1><samp>Orders</samp></h1>
             </div>

--- a/src/main/resources/templates/dashboard/products/create.html
+++ b/src/main/resources/templates/dashboard/products/create.html
@@ -41,7 +41,7 @@
     </div>
     <div class="row content-wrapper">
         <div th:replace="/fragments/sidebar :: sidebar" class="col-xs-2"></div>
-        <div class="col-xs-10 main">
+        <div class="col-xs-9 main">
             <div class="page-header">
                 <h1><samp>Create product</samp></h1>
             </div>

--- a/src/main/resources/templates/dashboard/products/edit.html
+++ b/src/main/resources/templates/dashboard/products/edit.html
@@ -42,7 +42,7 @@
     </div>
     <div class="row content-wrapper">
         <div th:replace="/fragments/sidebar :: sidebar" class="col-xs-2"></div>
-        <div class="col-xs-10 main">
+        <div class="col-xs-9 main">
             <div class="page-header">
                 <h1><samp>Edit product</samp></h1>
             </div>

--- a/src/main/resources/templates/dashboard/products/index.html
+++ b/src/main/resources/templates/dashboard/products/index.html
@@ -38,7 +38,7 @@
     </div>
     <div class="row content-wrapper">
         <div th:replace="/fragments/sidebar :: sidebar" class="col-xs-2"></div>
-        <div class="col-xs-10 main">
+        <div class="col-xs-9 main">
             <div class="page-header">
                 <h1><samp>Products</samp> <a class="btn btn-primary btn-dashboard-header" href="create/">Create new
                     product</a></h1>

--- a/src/main/resources/templates/dashboard/products/overview.html
+++ b/src/main/resources/templates/dashboard/products/overview.html
@@ -39,7 +39,7 @@
     <div class="row content-wrapper">
         <!--/*@thymesVar id="product" type="ch.wisv.events.core.model.product.Product"*/-->
         <div th:replace="/fragments/sidebar :: sidebar" class="col-xs-2"></div>
-        <div class="col-xs-10 main">
+        <div class="col-xs-9 main">
             <div class="page-header">
                 <h1><samp th:text="'Sold products for ' + ${product.getTitle()}"></samp></h1>
             </div>

--- a/src/main/resources/templates/dashboard/vendors/create.html
+++ b/src/main/resources/templates/dashboard/vendors/create.html
@@ -41,7 +41,7 @@
     </div>
     <div class="row content-wrapper">
         <div th:replace="/fragments/sidebar :: sidebar" class="col-xs-2"></div>
-        <div class="col-xs-10 main">
+        <div class="col-xs-9 main">
             <div class="page-header">
                 <h1><samp>Create vendor</samp></h1>
             </div>

--- a/src/main/resources/templates/dashboard/vendors/edit.html
+++ b/src/main/resources/templates/dashboard/vendors/edit.html
@@ -41,7 +41,7 @@
     </div>
     <div class="row content-wrapper">
         <div th:replace="/fragments/sidebar :: sidebar" class="col-xs-2"></div>
-        <div class="col-xs-10 main">
+        <div class="col-xs-9 main">
             <div class="page-header">
                 <h1><samp>Edit vendor</samp></h1>
             </div>

--- a/src/main/resources/templates/dashboard/vendors/index.html
+++ b/src/main/resources/templates/dashboard/vendors/index.html
@@ -38,7 +38,7 @@
     </div>
     <div class="row content-wrapper">
         <div th:replace="/fragments/sidebar :: sidebar" class="col-xs-2"></div>
-        <div class="col-xs-10 main">
+        <div class="col-xs-9 main">
             <div class="page-header">
                 <h1><samp>Vendors</samp>
                     <a class="btn btn-primary btn-dashboard-header" th:href="@{create/}">Create new vendor</a></h1>


### PR DESCRIPTION
In the dashboard, all views floated beneath the sidebar menu when the window was sized between xs and med. Changed all col-xs-10 to col-xs-9 to fix it