### PR TITLE
Update checkstyle.xml

### DIFF
--- a/.codeclimate/checkstyle.xml
+++ b/.codeclimate/checkstyle.xml
@@ -38,6 +38,11 @@
 
         <property name="basedir" value="${basedir}"/>
     -->
+        
+    <property name="severity" value="warning"/>
+    
+    <!-- The default severity is defined as ERROR.                                       -->
+    <!-- If left, Checkstyle abort the execution, which results in Code Climate erroring -->
 
     <property name="fileExtensions" value="java, properties, xml"/>
 


### PR DESCRIPTION
Hi @svenpopping -

Emily here with Code Climate Support. I've run across this once before with Checkstyle -- setting the severity to `warning` instead of relying on the default `error` should make this work for you.

You can find more info here: https://github.com/codeclimate/codeclimate-checkstyle/issues/19#issuecomment-339095604

Let me know if you have any other questions! 👍 