### PR TITLE
Add Datadog tracing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     compile 'com.google.guava:guava'
     compile 'org.hibernate:hibernate-validator'
     compile 'org.apache.commons:commons-lang3:3.5'
+    compile 'com.datadoghq:dd-trace-api:0.15.0'
 
     compile 'ch.wisv:wisvch-connect-client:1.3.1.7'
 

--- a/src/main/java/ch/wisv/events/core/tasks/OrderTaskScheduler.java
+++ b/src/main/java/ch/wisv/events/core/tasks/OrderTaskScheduler.java
@@ -5,11 +5,13 @@ import ch.wisv.events.core.model.order.Order;
 import ch.wisv.events.core.model.order.OrderStatus;
 import ch.wisv.events.core.service.order.OrderService;
 import ch.wisv.events.webshop.service.PaymentsService;
-import java.time.LocalDateTime;
+import datadog.trace.api.Trace;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.thymeleaf.util.ArrayUtils;
+
+import java.time.LocalDateTime;
 
 /**
  * OrderTaskScheduler class.
@@ -56,6 +58,7 @@ public class OrderTaskScheduler {
     /**
      * Cancel all overdue reservation.
      */
+    @Trace
     @Scheduled(fixedRate = CANCEL_RESERVATION_TASK_INTERVAL_SECONDS * MILLISEC_IN_SEC)
     public void cancelReservationTask() {
         orderService.getAllReservations().forEach(order -> {
@@ -73,6 +76,7 @@ public class OrderTaskScheduler {
     /**
      * Clean up order.
      */
+    @Trace
     @Scheduled(fixedRate = CLEAN_UP_TASK_INTERVAL_SECONDS * MILLISEC_IN_SEC)
     public void cleanUpTask() {
         orderService.getAllOrders().forEach(order -> {
@@ -90,6 +94,7 @@ public class OrderTaskScheduler {
     /**
      * Fetch the CH Payments order status.
      */
+    @Trace
     @Scheduled(fixedDelay = MILLISEC_UPDATE_ORDER_STATUS)
     public void updateOrderStatus() {
         orderService.getAllPending().forEach(this::fetchOrderStatus);

--- a/src/main/java/ch/wisv/events/webshop/service/PaymentsServiceImpl.java
+++ b/src/main/java/ch/wisv/events/webshop/service/PaymentsServiceImpl.java
@@ -9,7 +9,7 @@ import ch.wisv.events.core.model.order.Order;
 import ch.wisv.events.core.model.order.OrderStatus;
 import ch.wisv.events.core.service.mail.MailService;
 import ch.wisv.events.core.service.order.OrderService;
-import javax.validation.constraints.NotNull;
+import datadog.trace.api.Trace;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -25,6 +25,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotNull;
 
 /**
  * PaymentsService implementation.
@@ -88,6 +90,7 @@ public class PaymentsServiceImpl implements PaymentsService {
      *
      * @return String
      */
+    @Trace
     @Override
     public String getPaymentsOrderStatus(String paymentsReference) {
         try {
@@ -118,6 +121,7 @@ public class PaymentsServiceImpl implements PaymentsService {
      *
      * @return String
      */
+    @Trace
     @Override
     public String getPaymentsMollieUrl(Order order) {
         HttpPost httpPost = this.createPaymentsOrderHttpPost(order);


### PR DESCRIPTION
To scheduled tasks (currently only tracked because of outgoing HTTP
calls, but without context) and Payments API call methods.

https://docs.datadoghq.com/tracing/setup/java/#trace-annotation