### PR TITLE
Make upcoming events in overview clickable.

### DIFF
--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -151,7 +151,7 @@
                                 <tbody>
                                 <!--/*@thymesVar id="event" type="ch.wisv.events.core.model.event.Event"*/-->
                                 <tr th:each="event : ${upcoming}">
-                                    <td><a th:href="'events/view/' + ${event.getKey()}" th:text="${event.getTitle()}"></a></td>
+                                    <td><a th:href="@{'/administrator/events/view/' + ${event.getKey()} + '/'}" th:text="${event.getTitle()}"></a></td>
                                     <td>
                                         <div class="progress" style="margin-bottom: 0;">
                                             <div class="progress-bar" role="progressbar"

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -151,7 +151,7 @@
                                 <tbody>
                                 <!--/*@thymesVar id="event" type="ch.wisv.events.core.model.event.Event"*/-->
                                 <tr th:each="event : ${upcoming}">
-                                    <td th:text="${event.getTitle()}"></td>
+                                    <td><a th:href="'events/view/' + ${event.getKey()}" th:text="${event.getTitle()}"></a></td>
                                     <td>
                                         <div class="progress" style="margin-bottom: 0;">
                                             <div class="progress-bar" role="progressbar"

--- a/src/main/resources/templates/webshop/checkout/create.html
+++ b/src/main/resources/templates/webshop/checkout/create.html
@@ -48,9 +48,8 @@
                                                    name="email">
                                         </label>
                                         <small class="form-text text-muted help-text">
-                                            This should be a valid e-mail which you have access of, the tickets
-                                            will be send to this e-mail address. There is no other way of obtaining
-                                            your tickets.
+                                            This should be a valid e-mail address: your tickets will be sent there.
+                                            There is no other way of obtaining your tickets.
                                         </small>
                                     </div>
                                 </div>


### PR DESCRIPTION
I accidentally pushed to master (https://github.com/WISVCH/events/commit/9fa8b01083622a4a1226e0f6360f2af09f5ca630), and it was incorrect too. Shame on me. This should work.