### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
   - docker
   - postgresql
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter


### PR DESCRIPTION
Use `openjdk8` instead of defunct `oraclejdk8`.