### PR TITLE
Ticket transfer functionality

### DIFF
--- a/src/main/java/ch/wisv/events/core/exception/normal/TicketNotTransferableException.java
+++ b/src/main/java/ch/wisv/events/core/exception/normal/TicketNotTransferableException.java
@@ -20,6 +20,6 @@ public class TicketNotTransferableException extends EventsException {
      * @param message of type String
      */
     public TicketNotTransferableException(String message) {
-        super(LogLevelEnum.DEBUG, message);
+        super(LogLevelEnum.DEBUG, "Ticket is not transferable: " + message);
     }
 }

--- a/src/main/java/ch/wisv/events/core/exception/normal/TicketNotTransferableException.java
+++ b/src/main/java/ch/wisv/events/core/exception/normal/TicketNotTransferableException.java
@@ -1,0 +1,25 @@
+package ch.wisv.events.core.exception.normal;
+
+import ch.wisv.events.core.exception.LogLevelEnum;
+
+/**
+ * TicketNotFoundException class.
+ */
+public class TicketNotTransferableException extends EventsException {
+
+    /**
+     * TicketNotFoundException.
+     */
+    public TicketNotTransferableException() {
+        super(LogLevelEnum.DEBUG, "Ticket is not transferable");
+    }
+
+    /**
+     * TicketNotFoundException.
+     *
+     * @param message of type String
+     */
+    public TicketNotTransferableException(String message) {
+        super(LogLevelEnum.DEBUG, message);
+    }
+}

--- a/src/main/java/ch/wisv/events/core/model/customer/Customer.java
+++ b/src/main/java/ch/wisv/events/core/model/customer/Customer.java
@@ -14,6 +14,7 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
 
 /**
  * Customer object.
@@ -21,6 +22,10 @@ import lombok.Setter;
 @Entity
 @Data
 public class Customer {
+
+    /** Image location. */
+    @Value("${wisvch.connect.admin.groups}")
+    private String adminGroups;
 
     /**
      * Field id of the customer.
@@ -99,5 +104,14 @@ public class Customer {
         this.name = name;
         this.email = email;
         this.rfidToken = rfidToken;
+    }
+
+    /**
+     * Check if the customer has a ldap group that is also an admin group.
+     * @return boolean
+     */
+    public boolean isAdmin() {
+        List<String> adminGroups = List.of(this.adminGroups.split(","));
+        return this.ldapGroups.stream().anyMatch(ldapGroup -> adminGroups.contains(ldapGroup.getName()));
     }
 }

--- a/src/main/java/ch/wisv/events/core/model/product/Product.java
+++ b/src/main/java/ch/wisv/events/core/model/product/Product.java
@@ -98,13 +98,6 @@ public class Product {
     public List<Product> products;
 
     /**
-     * Event this product is for. Multiple products can be used by one Event.
-     * It is not necessary for a product to be linked to an Event.
-     */
-    @ManyToOne(targetEntity = Event.class,fetch = FetchType.EAGER)
-    public Event event;
-
-    /**
      * Flag if product is linked.
      */
     public boolean linked;

--- a/src/main/java/ch/wisv/events/core/model/product/Product.java
+++ b/src/main/java/ch/wisv/events/core/model/product/Product.java
@@ -6,13 +6,9 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.OneToMany;
+import javax.persistence.*;
+
+import ch.wisv.events.core.model.event.Event;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -100,6 +96,13 @@ public class Product {
      */
     @OneToMany(cascade = CascadeType.MERGE, targetEntity = Product.class, fetch = FetchType.EAGER)
     public List<Product> products;
+
+    /**
+     * Event this product is for. Multiple products can be used by one Event.
+     * It is not necessary for a product to be linked to an Event.
+     */
+    @ManyToOne(targetEntity = Event.class,fetch = FetchType.EAGER)
+    public Event event;
 
     /**
      * Flag if product is linked.

--- a/src/main/java/ch/wisv/events/core/model/ticket/Ticket.java
+++ b/src/main/java/ch/wisv/events/core/model/ticket/Ticket.java
@@ -92,4 +92,16 @@ public class Ticket {
         this.uniqueCode = uniqueCode;
         this.valid = true;
     }
+
+    /**
+     * Can the ticket be transferred to another customer by the given customer.
+     * This is only possible if the ticket is not scanned and not already transfered.
+     * The ticket can be transferred if the current customer is the owner of the ticket or if the current customer is an admin.
+     * @param customer of type Customer
+     *
+     * @return boolean
+     */
+    public boolean canTransfer(Customer customer) {
+        return this.status == TicketStatus.OPEN && (this.owner.equals(customer) || customer.isAdmin());
+    }
 }

--- a/src/main/java/ch/wisv/events/core/model/ticket/Ticket.java
+++ b/src/main/java/ch/wisv/events/core/model/ticket/Ticket.java
@@ -104,15 +104,22 @@ public class Ticket {
      */
     public void canTransfer(Customer currentCustomer, Customer newCustomer) throws TicketNotTransferableException {
         // Check if the ticket is not scanned and not already transferred and if the ticket is valid.
-        if(this.status != TicketStatus.OPEN || !this.valid)
-            throw new TicketNotTransferableException("Ticket is already scanned or not valid.");
+        if(this.status != TicketStatus.OPEN)
+            throw new TicketNotTransferableException("Ticket is already scanned.");
+
+        if(!this.valid)
+            throw new TicketNotTransferableException("Ticket is not valid.");
 
         // Check if the ticket is a CH Only product and if the new customer is not a verified CH customer.
         if(newCustomer != null && this.product.isChOnly() && !newCustomer.isVerifiedChMember())
             throw new TicketNotTransferableException("Ticket can only be transferred to a verified CH member.");
 
-        // Check if the current customer is the owner of the ticket or if the current customer is an admin.
-        if (!this.owner.equals(currentCustomer) && !currentCustomer.isAdmin())
+        // Check if the current customer is the owner of the ticket
+        if (!this.owner.equals(currentCustomer))
             throw new TicketNotTransferableException("Ticket can only be transferred to the owner.");
+
+        // Check if ticket is not transferred to the same customer.
+        if(this.owner.equals(newCustomer))
+            throw new TicketNotTransferableException("Sadly you can not transfer a ticket to yourself.. Lezen is adten.");
     }
 }

--- a/src/main/java/ch/wisv/events/core/model/ticket/Ticket.java
+++ b/src/main/java/ch/wisv/events/core/model/ticket/Ticket.java
@@ -1,5 +1,6 @@
 package ch.wisv.events.core.model.ticket;
 
+import ch.wisv.events.core.exception.normal.TicketNotTransferableException;
 import ch.wisv.events.core.model.customer.Customer;
 import ch.wisv.events.core.model.order.Order;
 import ch.wisv.events.core.model.product.Product;
@@ -98,23 +99,20 @@ public class Ticket {
      * This is only possible if the ticket is not scanned and not already transferred and if the ticket is valid.
      * Tickets of CH Only products can only be transferred to Verified CH customers.
      * The ticket can be transferred if the current customer is the owner of the ticket or if the current customer is an admin.
-     * @param customer of type Customer
-     *
-     * @return boolean
+     * @param currentCustomer of type Customer
+     * @param newCustomer of type Customer
      */
-    public boolean canTransfer(Customer customer) {
+    public void canTransfer(Customer currentCustomer, Customer newCustomer) throws TicketNotTransferableException {
         // Check if the ticket is not scanned and not already transferred and if the ticket is valid.
         if(this.status != TicketStatus.OPEN || !this.valid)
-            return false;
+            throw new TicketNotTransferableException("Ticket is already scanned or not valid.");
 
-        // Check if the product is of type CH Only
-        if(this.product.isChOnly() && !customer.isVerifiedChMember())
-            return false;
+        // Check if the ticket is a CH Only product and if the new customer is not a verified CH customer.
+        if(newCustomer != null && this.product.isChOnly() && !newCustomer.isVerifiedChMember())
+            throw new TicketNotTransferableException("Ticket can only be transferred to a verified CH member.");
 
         // Check if the current customer is the owner of the ticket or if the current customer is an admin.
-        if (!this.owner.equals(customer) && !customer.isAdmin())
-            return false;
-
-        return true;
+        if (!this.owner.equals(currentCustomer) && !currentCustomer.isAdmin())
+            throw new TicketNotTransferableException("Ticket can only be transferred to the owner.");
     }
 }

--- a/src/main/java/ch/wisv/events/core/model/ticket/Ticket.java
+++ b/src/main/java/ch/wisv/events/core/model/ticket/Ticket.java
@@ -2,8 +2,11 @@ package ch.wisv.events.core.model.ticket;
 
 import ch.wisv.events.core.exception.normal.TicketNotTransferableException;
 import ch.wisv.events.core.model.customer.Customer;
+import ch.wisv.events.core.model.event.Event;
 import ch.wisv.events.core.model.order.Order;
 import ch.wisv.events.core.model.product.Product;
+
+import java.time.LocalDateTime;
 import java.util.UUID;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -109,6 +112,11 @@ public class Ticket {
 
         if(!this.valid)
             throw new TicketNotTransferableException("Ticket is not valid.");
+
+        Event event = this.product.getEvent();
+        // Check when the ticket product is linked to an event if that event has not passed.
+        if(event != null && LocalDateTime.now().isAfter(event.getEnding()))
+            throw new TicketNotTransferableException("Related event has already passed.");
 
         // Check if the ticket is a CH Only product and if the new customer is not a verified CH customer.
         if(newCustomer != null && this.product.isChOnly() && !newCustomer.isVerifiedChMember())

--- a/src/main/java/ch/wisv/events/core/model/ticket/Ticket.java
+++ b/src/main/java/ch/wisv/events/core/model/ticket/Ticket.java
@@ -105,7 +105,7 @@ public class Ticket {
      * @param currentCustomer of type Customer
      * @param newCustomer of type Customer
      */
-    public void canTransfer(Customer currentCustomer, Customer newCustomer) throws TicketNotTransferableException {
+    public boolean canTransfer(Customer currentCustomer, Customer newCustomer, Event event) throws TicketNotTransferableException {
         // Check if the ticket is not scanned and not already transferred and if the ticket is valid.
         if(this.status != TicketStatus.OPEN)
             throw new TicketNotTransferableException("Ticket is already scanned.");
@@ -113,7 +113,6 @@ public class Ticket {
         if(!this.valid)
             throw new TicketNotTransferableException("Ticket is not valid.");
 
-        Event event = this.product.getEvent();
         // Check when the ticket product is linked to an event if that event has not passed.
         if(event != null && LocalDateTime.now().isAfter(event.getEnding()))
             throw new TicketNotTransferableException("Related event has already passed.");
@@ -127,7 +126,9 @@ public class Ticket {
             throw new TicketNotTransferableException("Ticket can only be transferred to the owner.");
 
         // Check if ticket is not transferred to the same customer.
-        if(this.owner.equals(newCustomer))
+        if(newCustomer != null && this.owner.equals(newCustomer))
             throw new TicketNotTransferableException("Sadly you can not transfer a ticket to yourself.. Lezen is adten.");
+
+        return true;
     }
 }

--- a/src/main/java/ch/wisv/events/core/model/ticket/Ticket.java
+++ b/src/main/java/ch/wisv/events/core/model/ticket/Ticket.java
@@ -95,13 +95,26 @@ public class Ticket {
 
     /**
      * Can the ticket be transferred to another customer by the given customer.
-     * This is only possible if the ticket is not scanned and not already transfered.
+     * This is only possible if the ticket is not scanned and not already transferred and if the ticket is valid.
+     * Tickets of CH Only products can only be transferred to Verified CH customers.
      * The ticket can be transferred if the current customer is the owner of the ticket or if the current customer is an admin.
      * @param customer of type Customer
      *
      * @return boolean
      */
     public boolean canTransfer(Customer customer) {
-        return this.status == TicketStatus.OPEN && (this.owner.equals(customer) || customer.isAdmin());
+        // Check if the ticket is not scanned and not already transferred and if the ticket is valid.
+        if(this.status != TicketStatus.OPEN || !this.valid)
+            return false;
+
+        // Check if the product is of type CH Only
+        if(this.product.isChOnly() && !customer.isVerifiedChMember())
+            return false;
+
+        // Check if the current customer is the owner of the ticket or if the current customer is an admin.
+        if (!this.owner.equals(customer) && !customer.isAdmin())
+            return false;
+
+        return true;
     }
 }

--- a/src/main/java/ch/wisv/events/core/service/mail/MailService.java
+++ b/src/main/java/ch/wisv/events/core/service/mail/MailService.java
@@ -1,5 +1,6 @@
 package ch.wisv.events.core.service.mail;
 
+import ch.wisv.events.core.model.customer.Customer;
 import ch.wisv.events.core.model.order.Order;
 import ch.wisv.events.core.model.ticket.Ticket;
 import java.util.List;
@@ -16,6 +17,14 @@ public interface MailService {
      * @param tickets of type List of Tickets
      */
     void sendOrderConfirmation(Order order, List<Ticket> tickets);
+
+    /**
+     * Method mail Transfer confirmation to Customer.
+     * @param ticket of type Ticket
+     * @param oldCustomer of type Customer
+     * @param newCustomer of type Customer
+     */
+    void sendTransferConfirmation(Ticket ticket, Customer oldCustomer, Customer newCustomer);
 
     /**
      * Method mails about a payment error.

--- a/src/main/java/ch/wisv/events/core/service/mail/MailServiceImpl.java
+++ b/src/main/java/ch/wisv/events/core/service/mail/MailServiceImpl.java
@@ -1,6 +1,7 @@
 package ch.wisv.events.core.service.mail;
 
 import biweekly.util.IOUtils;
+import ch.wisv.events.core.model.customer.Customer;
 import ch.wisv.events.core.model.order.Order;
 import ch.wisv.events.core.model.ticket.Ticket;
 
@@ -69,6 +70,27 @@ public class MailServiceImpl implements MailService {
         }
     }
 
+
+
+    /**
+     * Method mail transferred ticket to Customer.
+     * @param ticket of type Ticket
+     * @param oldCustomer of type Customer
+     * @param newCustomer of type Customer
+     */
+    @Override
+    public void sendTransferConfirmation(Ticket ticket, Customer oldCustomer, Customer newCustomer) {
+        final Context ctx = new Context(new Locale("en"));
+        ctx.setVariable("tickets", ticket);
+        ctx.setVariable("oldCustomer", oldCustomer);
+        ctx.setVariable("oldCustomer", oldCustomer);
+        ctx.setVariable("redirectLink", ticket.getProduct().getRedirectUrl());
+        String subject = String.format("Ticket transfer %s", ticket.getProduct().getTitle());
+
+        List<String> barcodes = List.of(ticket.getUniqueCode());
+        this.sendMailWithContent(newCustomer.getEmail(), subject, this.templateEngine.process("mail/transfer", ctx), barcodes);
+    }
+
     /**
      * Method mails about a error.
      *
@@ -114,7 +136,7 @@ public class MailServiceImpl implements MailService {
      * @param recipientEmail of type String
      * @param subject        of type String
      * @param content        of type String
-     * @param barcode        of type String
+     * @param barcodes       list of type String
      */
     private void sendMailWithContent(String recipientEmail, String subject, String content, List<String> barcodes) {
         // Prepare message using a Spring helper

--- a/src/main/java/ch/wisv/events/core/service/mail/MailServiceImpl.java
+++ b/src/main/java/ch/wisv/events/core/service/mail/MailServiceImpl.java
@@ -81,7 +81,7 @@ public class MailServiceImpl implements MailService {
     @Override
     public void sendTransferConfirmation(Ticket ticket, Customer oldCustomer, Customer newCustomer) {
         final Context ctx = new Context(new Locale("en"));
-        ctx.setVariable("tickets", ticket);
+        ctx.setVariable("ticket", ticket);
         ctx.setVariable("oldCustomer", oldCustomer);
         ctx.setVariable("oldCustomer", oldCustomer);
         ctx.setVariable("redirectLink", ticket.getProduct().getRedirectUrl());

--- a/src/main/java/ch/wisv/events/core/service/order/OrderServiceImpl.java
+++ b/src/main/java/ch/wisv/events/core/service/order/OrderServiceImpl.java
@@ -90,7 +90,8 @@ public class OrderServiceImpl implements OrderService {
     public OrderServiceImpl(
             OrderRepository orderRepository, OrderProductRepository orderProductRepository,
             OrderValidationService orderValidationService, ProductService productService,
-            MailService mailService, TicketService ticketService
+            MailService mailService, TicketService
+                    ticketService
     ) {
         this.orderRepository = orderRepository;
         this.orderProductRepository = orderProductRepository;
@@ -424,6 +425,4 @@ public class OrderServiceImpl implements OrderService {
         log.info("Order " + order.getPublicReference() + ": Status changed to RESERVATION!");
         orderRepository.saveAndFlush(order);
     }
-
-
 }

--- a/src/main/java/ch/wisv/events/core/service/ticket/TicketService.java
+++ b/src/main/java/ch/wisv/events/core/service/ticket/TicketService.java
@@ -104,4 +104,10 @@ public interface TicketService {
      */
     List<Ticket> getAll();
 
+    /**
+     * Transfer a Ticket to another Customer.
+     * @param customer of type Customer
+     */
+    void transfer(Ticket ticket, Customer customer);
+
 }

--- a/src/main/java/ch/wisv/events/core/service/ticket/TicketService.java
+++ b/src/main/java/ch/wisv/events/core/service/ticket/TicketService.java
@@ -1,6 +1,7 @@
 package ch.wisv.events.core.service.ticket;
 
 import ch.wisv.events.core.exception.normal.TicketNotFoundException;
+import ch.wisv.events.core.exception.normal.TicketNotTransferableException;
 import ch.wisv.events.core.model.customer.Customer;
 import ch.wisv.events.core.model.order.Order;
 import ch.wisv.events.core.model.product.Product;
@@ -106,8 +107,9 @@ public interface TicketService {
 
     /**
      * Transfer a Ticket to another Customer.
-     * @param customer of type Customer
+     * @param currentCustomer of type Customer
+     * @param newCustomer of type Customer
      */
-    void transfer(Ticket ticket, Customer customer);
+    void transfer(Ticket ticket, Customer currentCustomer, Customer newCustomer) throws TicketNotTransferableException;
 
 }

--- a/src/main/java/ch/wisv/events/core/service/ticket/TicketServiceImpl.java
+++ b/src/main/java/ch/wisv/events/core/service/ticket/TicketServiceImpl.java
@@ -11,6 +11,8 @@ import ch.wisv.events.core.model.ticket.TicketStatus;
 import ch.wisv.events.core.repository.TicketRepository;
 import java.util.ArrayList;
 import java.util.List;
+
+import ch.wisv.events.core.service.mail.MailService;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.stereotype.Service;
 
@@ -30,12 +32,19 @@ public class TicketServiceImpl implements TicketService {
     private final TicketRepository ticketRepository;
 
     /**
+     * MailService.
+     */
+    private final MailService mailService;
+
+    /**
      * TicketServiceImpl constructor.
      *
      * @param ticketRepository of type TicketRepository
+     * @param mailService of type MailService
      */
-    public TicketServiceImpl(TicketRepository ticketRepository) {
+    public TicketServiceImpl(TicketRepository ticketRepository, MailService mailService) {
         this.ticketRepository = ticketRepository;
+        this.mailService = mailService;
     }
 
     /**
@@ -216,6 +225,9 @@ public class TicketServiceImpl implements TicketService {
         ticket.setOwner(newCustomer);
 
         ticketRepository.saveAndFlush(ticket);
+
+        // Send email to new customer
+        mailService.sendTransferConfirmation(ticket, currentCustomer, newCustomer);
     }
 
 }

--- a/src/main/java/ch/wisv/events/core/service/ticket/TicketServiceImpl.java
+++ b/src/main/java/ch/wisv/events/core/service/ticket/TicketServiceImpl.java
@@ -1,6 +1,7 @@
 package ch.wisv.events.core.service.ticket;
 
 import ch.wisv.events.core.exception.normal.TicketNotFoundException;
+import ch.wisv.events.core.exception.normal.TicketNotTransferableException;
 import ch.wisv.events.core.model.customer.Customer;
 import ch.wisv.events.core.model.order.Order;
 import ch.wisv.events.core.model.order.OrderProduct;
@@ -200,15 +201,19 @@ public class TicketServiceImpl implements TicketService {
 
     /**
      * Transfer a Ticket to another Customer.
-     * @param customer of type Customer
+     * @param currentCustomer of type Customer
+     * @param newCustomer of type Customer
      */
-    public void transfer(Ticket ticket, Customer customer) {
+    public void transfer(Ticket ticket, Customer currentCustomer, Customer newCustomer) throws TicketNotTransferableException {
+        // Check if the ticket can be transferred
+        ticket.canTransfer(currentCustomer, newCustomer);
+
         // Generate new unique code
         String uniqueCode = this.generateUniqueString(ticket.getProduct());
 
         // Update ticket
         ticket.setUniqueCode(uniqueCode);
-        ticket.setOwner(customer);
+        ticket.setOwner(newCustomer);
 
         ticketRepository.saveAndFlush(ticket);
     }

--- a/src/main/java/ch/wisv/events/core/service/ticket/TicketServiceImpl.java
+++ b/src/main/java/ch/wisv/events/core/service/ticket/TicketServiceImpl.java
@@ -198,4 +198,19 @@ public class TicketServiceImpl implements TicketService {
         return ticketUnique;
     }
 
+    /**
+     * Transfer a Ticket to another Customer.
+     * @param customer of type Customer
+     */
+    public void transfer(Ticket ticket, Customer customer) {
+        // Generate new unique code
+        String uniqueCode = this.generateUniqueString(ticket.getProduct());
+
+        // Update ticket
+        ticket.setUniqueCode(uniqueCode);
+        ticket.setOwner(customer);
+
+        ticketRepository.saveAndFlush(ticket);
+    }
+
 }

--- a/src/main/java/ch/wisv/events/webshop/controller/WebshopCustomerController.java
+++ b/src/main/java/ch/wisv/events/webshop/controller/WebshopCustomerController.java
@@ -32,7 +32,10 @@ public class WebshopCustomerController extends WebshopController {
     /** Redirect to the payment page. */
     private static final String REDIRECT_CHECKOUT_PAYMENT = "redirect:/checkout/%s/payment";
 
-    /** Redirect to the customer create page. */
+    /** Redirect to the CH Connect customer checkout page. */
+    private static final String REDIRECT_CHECKOUT_CUSTOMER_CHCONNECT = "redirect:/checkout/%s/customer/chconnect";
+
+    /** Redirect to the Guest customer checkout page. */
     private static final String REDIRECT_CHECKOUT_CUSTOMER_GUEST = "redirect:/checkout/%s/customer/guest";
 
     /** CustomerService. */
@@ -76,7 +79,11 @@ public class WebshopCustomerController extends WebshopController {
                 return this.orderCheck(order);
             }
 
-            model.addAttribute(MODEL_ATTR_CUSTOMER, authenticationService.getCurrentCustomer());
+            Customer customer = authenticationService.getCurrentCustomer();
+            if(customer != null) {
+                return String.format(REDIRECT_CHECKOUT_CUSTOMER_CHCONNECT, key);
+            }
+
             model.addAttribute(MODEL_ATTR_ORDER, order);
             model.addAttribute("chOnly", orderService.containsChOnlyProduct(order));
 

--- a/src/main/java/ch/wisv/events/webshop/controller/WebshopCustomerController.java
+++ b/src/main/java/ch/wisv/events/webshop/controller/WebshopCustomerController.java
@@ -32,10 +32,7 @@ public class WebshopCustomerController extends WebshopController {
     /** Redirect to the payment page. */
     private static final String REDIRECT_CHECKOUT_PAYMENT = "redirect:/checkout/%s/payment";
 
-    /** Redirect to the CH Connect customer checkout page. */
-    private static final String REDIRECT_CHECKOUT_CUSTOMER_CHCONNECT = "redirect:/checkout/%s/customer/chconnect";
-
-    /** Redirect to the Guest customer checkout page. */
+    /** Redirect to the customer create page. */
     private static final String REDIRECT_CHECKOUT_CUSTOMER_GUEST = "redirect:/checkout/%s/customer/guest";
 
     /** CustomerService. */
@@ -79,11 +76,7 @@ public class WebshopCustomerController extends WebshopController {
                 return this.orderCheck(order);
             }
 
-            Customer customer = authenticationService.getCurrentCustomer();
-            if(customer != null) {
-                return String.format(REDIRECT_CHECKOUT_CUSTOMER_CHCONNECT, key);
-            }
-
+            model.addAttribute(MODEL_ATTR_CUSTOMER, authenticationService.getCurrentCustomer());
             model.addAttribute(MODEL_ATTR_ORDER, order);
             model.addAttribute("chOnly", orderService.containsChOnlyProduct(order));
 

--- a/src/main/java/ch/wisv/events/webshop/controller/WebshopReturnController.java
+++ b/src/main/java/ch/wisv/events/webshop/controller/WebshopReturnController.java
@@ -1,6 +1,7 @@
 package ch.wisv.events.webshop.controller;
 
 import ch.wisv.events.core.exception.normal.OrderNotFoundException;
+import ch.wisv.events.core.model.customer.Customer;
 import ch.wisv.events.core.model.order.Order;
 import ch.wisv.events.core.model.order.OrderProduct;
 import ch.wisv.events.core.model.product.Product;
@@ -58,6 +59,7 @@ public class WebshopReturnController extends WebshopController {
                     .collect(Collectors.toList());
 
             model.addAttribute(MODEL_ATTR_REDIRECT_PRODUCTS, productsWithRedirect);
+            model.addAttribute(MODEL_ATTR_CUSTOMER, authenticationService.getCurrentCustomer());
 
             switch (order.getStatus()) {
                 case PENDING:

--- a/src/main/java/ch/wisv/events/webshop/controller/WebshopReturnController.java
+++ b/src/main/java/ch/wisv/events/webshop/controller/WebshopReturnController.java
@@ -1,7 +1,6 @@
 package ch.wisv.events.webshop.controller;
 
 import ch.wisv.events.core.exception.normal.OrderNotFoundException;
-import ch.wisv.events.core.model.customer.Customer;
 import ch.wisv.events.core.model.order.Order;
 import ch.wisv.events.core.model.order.OrderProduct;
 import ch.wisv.events.core.model.product.Product;
@@ -59,7 +58,6 @@ public class WebshopReturnController extends WebshopController {
                     .collect(Collectors.toList());
 
             model.addAttribute(MODEL_ATTR_REDIRECT_PRODUCTS, productsWithRedirect);
-            model.addAttribute(MODEL_ATTR_CUSTOMER, authenticationService.getCurrentCustomer());
 
             switch (order.getStatus()) {
                 case PENDING:

--- a/src/main/java/ch/wisv/events/webshop/controller/WebshopTicketController.java
+++ b/src/main/java/ch/wisv/events/webshop/controller/WebshopTicketController.java
@@ -59,8 +59,8 @@ public class WebshopTicketController extends WebshopController {
         try {
             Ticket ticket = ticketService.getByKey(key);
 
-            if(!ticket.canTransfer(customer))
-                throw new TicketNotTransferableException();
+
+            ticket.canTransfer(customer, null);
 
             model.addAttribute(MODEL_ATTR_CUSTOMER, customer);
             model.addAttribute(MODEL_ATTR_TICKET, ticket);
@@ -84,20 +84,18 @@ public class WebshopTicketController extends WebshopController {
      */
     @PostMapping("/{key}/transfer")
     public String transferTicket(Model model, RedirectAttributes redirect, @PathVariable String key, @RequestParam("email") String email) {
-        Customer customer = authenticationService.getCurrentCustomer();
+        Customer currentCustomer = authenticationService.getCurrentCustomer();
 
         try {
             Ticket ticket = ticketService.getByKey(key);
 
-            if(!ticket.canTransfer(customer))
-                throw new TicketNotTransferableException();
+            // Find new customer by email
+            Customer newCustomer = customerService.getByEmail(email);
 
-            // Check if customer with email exists
-            Customer transferCustomer = customerService.getByEmail(email);
+            // Transfer the ticket
+            ticketService.transfer(ticket, currentCustomer, newCustomer);
 
-            ticketService.transfer(ticket, transferCustomer);
-
-            redirect.addFlashAttribute("MODEL_ATTR_SUCCESS", "Ticket has been transferred to " + transferCustomer.getEmail());
+            redirect.addFlashAttribute("MODEL_ATTR_SUCCESS", "Ticket has been transferred to " + newCustomer.getEmail());
 
             return "redirect:/overview";
         }

--- a/src/main/java/ch/wisv/events/webshop/controller/WebshopTicketController.java
+++ b/src/main/java/ch/wisv/events/webshop/controller/WebshopTicketController.java
@@ -1,6 +1,7 @@
 package ch.wisv.events.webshop.controller;
 
 import ch.wisv.events.core.exception.normal.CustomerNotFoundException;
+import ch.wisv.events.core.exception.normal.TicketNotFoundException;
 import ch.wisv.events.core.exception.normal.TicketNotTransferableException;
 import ch.wisv.events.core.model.customer.Customer;
 import ch.wisv.events.core.model.ticket.Ticket;
@@ -59,16 +60,19 @@ public class WebshopTicketController extends WebshopController {
         try {
             Ticket ticket = ticketService.getByKey(key);
 
-
-            ticket.canTransfer(customer, null);
+            ticket.canTransfer(customer, null, null);
 
             model.addAttribute(MODEL_ATTR_CUSTOMER, customer);
             model.addAttribute(MODEL_ATTR_TICKET, ticket);
 
             return "webshop/tickets/transfer";
         }
+        catch (TicketNotFoundException e){
+            redirect.addFlashAttribute(MODEL_ATTR_ERROR, "Ticket not found");
+            return "redirect:/overview";
+        }
         catch (TicketNotTransferableException e) {
-            redirect.addFlashAttribute("MODEL_ATTR_ERROR", "Ticket is not transferable");
+            redirect.addFlashAttribute(MODEL_ATTR_ERROR, e.getMessage());
             return "redirect:/overview";
         }
         catch (Exception e) {
@@ -95,12 +99,16 @@ public class WebshopTicketController extends WebshopController {
             // Transfer the ticket
             ticketService.transfer(ticket, currentCustomer, newCustomer);
 
-            redirect.addFlashAttribute("MODEL_ATTR_SUCCESS", "Ticket has been transferred to " + newCustomer.getEmail());
+            redirect.addFlashAttribute(MODEL_ATTR_SUCCESS, "Ticket has been transferred to " + newCustomer.getEmail());
 
             return "redirect:/overview";
         }
+        catch (TicketNotFoundException e){
+            redirect.addFlashAttribute(MODEL_ATTR_ERROR, "Ticket not found");
+            return "redirect:/overview";
+        }
         catch (TicketNotTransferableException e) {
-            redirect.addFlashAttribute("MODEL_ATTR_ERROR", "Ticket is not transferable");
+            redirect.addFlashAttribute(MODEL_ATTR_ERROR, e.getMessage());
             return "redirect:/overview";
         }
         catch (CustomerNotFoundException e) {

--- a/src/main/java/ch/wisv/events/webshop/controller/WebshopTicketController.java
+++ b/src/main/java/ch/wisv/events/webshop/controller/WebshopTicketController.java
@@ -1,0 +1,64 @@
+package ch.wisv.events.webshop.controller;
+
+import ch.wisv.events.core.model.customer.Customer;
+import ch.wisv.events.core.model.ticket.Ticket;
+import ch.wisv.events.core.service.auth.AuthenticationService;
+import ch.wisv.events.core.service.order.OrderService;
+import ch.wisv.events.core.service.ticket.TicketService;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * WebshopOrderOverviewController class.
+ */
+@Controller
+@RequestMapping("/tickets")
+@PreAuthorize("hasAuthority('ROLE_USER')")
+public class WebshopTicketController extends WebshopController {
+    /** Model attribute tickets. */
+    private static final String MODEL_ATTR_TICKET = "ticket";
+
+    /** TicketService. */
+    private final TicketService ticketService;
+
+    /**
+     * @param authenticationService of type AuthenticationService
+     * @param orderService          of type OrderService
+     * @param ticketService         of type TicketService
+     */
+    public WebshopTicketController(
+            AuthenticationService authenticationService,
+            OrderService orderService,
+            TicketService ticketService
+    ) {
+        super(orderService, authenticationService);
+        this.ticketService = ticketService;
+    }
+
+    /** Get ticket transfer page.
+     * @param model    of type Model
+     * @param key      of type String
+     *
+     * @return String
+     */
+    @GetMapping("/{key}/transfer")
+    public String getTransferPage(Model model, @PathVariable String key) {
+        Customer customer = authenticationService.getCurrentCustomer();
+
+        try {
+            Ticket ticket = ticketService.getByKey(key);
+
+            model.addAttribute(MODEL_ATTR_CUSTOMER, customer);
+            model.addAttribute(MODEL_ATTR_TICKET, ticket);
+
+            return "webshop/tickets/transfer";
+        }
+        catch (Exception e) {
+            return "redirect:/overview";
+        }
+    }
+}

--- a/src/main/resources/templates/mail/order.html
+++ b/src/main/resources/templates/mail/order.html
@@ -234,7 +234,7 @@
                                         <br/>
                                         <span style="font-size: 24px;">Thanks for your purchase!</span><br/>
                                         Your order has been completed! In this email you find a copy of your order.
-                                        Tickets can be traded by handing over the unique code to one another.
+                                        Tickets can be transferred by using the transfer button in your account under "My Events" => "My tickets", or by handing over the unique code to one another.
                                         <br/>
                                         <br/>
                                     </td>
@@ -326,7 +326,7 @@
                                                                  style="border-collapse: collapse !important;">
                                                     <tr>
                                                         <td>
-                                                            <h3>Form links for your orders!</h3>
+                                                            <h3>Links for your tickets!</h3>
                                                         </td>
                                                     </tr>
                                                     <tr>

--- a/src/main/resources/templates/mail/transfer.html
+++ b/src/main/resources/templates/mail/transfer.html
@@ -232,7 +232,7 @@
                                     <td style="color: #ffffff;font-family: Arial, sans-serif;font-size: 16px;text-align: center;border-collapse: collapse;padding-right: 30px;padding-left: 20px;"
                                         class="header-text">
                                         <br/>
-                                        <span style="font-size: 24px;"><span th:text="${oldCustomer.getName()}"></span> send you a ticket!</span><br/>
+                                        <span style="font-size: 24px;"><span th:text="${oldCustomer.getName()}"></span> has sent you a ticket!</span><br/>
                                         <span th:text="${oldCustomer.getName()}"></span> transferred a ticket to you. In this email you find a newly generated barcode.
                                         <br/>
                                         <br/>

--- a/src/main/resources/templates/mail/transfer.html
+++ b/src/main/resources/templates/mail/transfer.html
@@ -1,0 +1,354 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>CH Events mail</title>
+    <!-- Designed by https://github.com/kaytcat -->
+    <!-- Header image designed by Freepik.com -->
+
+    <style type="text/css">
+        /* Take care of image borders and formatting */
+
+        img {
+            max-width: 600px;
+            outline: none;
+            text-decoration: none;
+            -ms-interpolation-mode: bicubic;
+        }
+
+        a img {
+            border: none;
+        }
+
+        img.barcode {
+            width: 226px;
+            height: 100px;
+            display: block;
+        }
+
+        table {
+            border-collapse: collapse !important;
+        }
+
+        #outlook a {
+            padding: 0;
+        }
+
+        .ReadMsgBody {
+            width: 100%;
+        }
+
+        .ExternalClass {
+            width: 100%;
+        }
+
+        .backgroundTable {
+            margin: 0 auto;
+            padding: 0;
+            width: 100%;
+        !important;
+        }
+
+        table td {
+            border-collapse: collapse;
+        }
+
+        .ExternalClass * {
+            line-height: 115%;
+        }
+
+        /* General styling */
+
+        td {
+            font-family: Arial, sans-serif;
+            color: #5e5e5e;
+            font-size: 16px;
+            text-align: left;
+        }
+
+        body {
+            -webkit-font-smoothing: antialiased;
+            -webkit-text-size-adjust: none;
+            width: 100%;
+            height: 100%;
+            color: #5e5e5e;
+            font-weight: 400;
+            font-size: 16px;
+        }
+
+        h1 {
+            margin: 10px 0;
+        }
+
+        a {
+            color: #2b934f;
+            text-decoration: none;
+        }
+
+        .body-padding {
+            padding: 0 75px;
+        }
+
+        .force-full-width {
+            width: 100% !important;
+        }
+
+        .icons {
+            text-align: right;
+            padding-right: 30px;
+        }
+
+        .logo {
+            text-align: center;
+            padding-left: 30px;
+        }
+
+        .logo img {
+            width: 90%;
+        }
+
+        .computer-image {
+            padding-left: 30px;
+        }
+
+        .header-text {
+            text-align: center;
+            padding-right: 30px;
+            padding-left: 20px;
+        }
+
+        .header {
+            color: #232925;
+            font-size: 24px;
+        }
+
+        .grey-header {
+            background-color: #dedede;
+            padding: 5px;
+            font-weight: bold;
+        }
+
+        .white-header {
+            background-color: #f3f3f3;
+            padding: 5px;
+        }
+
+
+    </style>
+    <style type="text/css" media="screen">
+        @media screen {
+            @import url(http://fonts.googleapis.com/css?family=PT+Sans:400,700);
+            /* Thanks Outlook 2013! */
+            * {
+                font-family: 'PT Sans', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
+            }
+        }
+    </style>
+    <style type="text/css" media="only screen and (max-width: 599px)">
+        /* Mobile styles */
+        @media only screen and (max-width: 599px) {
+
+            table[class*="w320"] {
+                width: 320px !important;
+            }
+
+            td[class*="icons"] {
+                display: block !important;
+                text-align: center !important;
+                padding: 0 !important;
+            }
+
+            td[class*="logo"] {
+                display: block !important;
+                text-align: center !important;
+                padding: 0 !important;
+            }
+
+            td[class*="computer-image"] {
+                display: block !important;
+                width: 230px !important;
+                padding: 0 45px !important;
+                border-bottom: 1px solid #e3e3e3 !important;
+            }
+
+            td[class*="header-text"] {
+                display: block !important;
+                text-align: center !important;
+                padding: 0 25px !important;
+                padding-bottom: 25px !important;
+            }
+
+            *[class*="mobile-hide"] {
+                display: none !important;
+                width: 0 !important;
+                height: 0 !important;
+                line-height: 0 !important;
+                font-size: 0 !important;
+            }
+
+            td[class="mobile-block"] {
+                display: block !important;
+                width: 260px !important;
+            }
+
+        }
+    </style>
+</head>
+<body offset="0" class="body"
+      style="padding: 0;margin: 0;display: block;background: #ffffff;-webkit-text-size-adjust: none;-webkit-font-smoothing: antialiased;width: 100%;height: 100%;color: #5e5e5e;font-weight: 400;font-size: 16px;"
+      bgcolor="#ffffff">
+<table align="center" cellpadding="0" cellspacing="0" width="100%" height="100%"
+       style="border-collapse: collapse !important;">
+    <tr>
+        <td align="center" valign="top"
+            style="background-color: #ffffff;font-family: Arial, sans-serif;color: #5e5e5e;font-size: 16px;text-align: left;border-collapse: collapse;"
+            width="100%">
+
+            <center>
+                <table cellspacing="0" cellpadding="0" width="600" class="w320"
+                       style="border-collapse: collapse !important;">
+                    <tr>
+                        <td align="center" valign="top"
+                            style="font-family: Arial, sans-serif;color: #5e5e5e;font-size: 16px;text-align: left;border-collapse: collapse;">
+
+                            <table class="force-full-width" cellspacing="0" cellpadding="0" bgcolor="#415569"
+                                   style="border-collapse: collapse !important;width: 100% !important;">
+                                <tr>
+                                    <td style="background-color: #1E274A;font-family: Arial, sans-serif;color: #5e5e5e;font-size: 16px;text-align: center;border-collapse: collapse;"
+                                        class="logo">
+                                        <br/>
+                                        <img src="cid:ch-logo.png"
+                                             alt="Logo"
+                                             style="max-width: 600px;outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;"/>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <table cellspacing="0" cellpadding="0" class="force-full-width" bgcolor="#1E274A"
+                                   style="border-collapse: collapse !important;width: 100% !important;">
+                                <tr>
+                                    <td style="color: #ffffff;font-family: Arial, sans-serif;font-size: 16px;text-align: center;border-collapse: collapse;padding-right: 30px;padding-left: 20px;"
+                                        class="header-text">
+                                        <br/>
+                                        <span style="font-size: 24px;"><span th:text="${oldCustomer.getName()}"></span> send you a ticket!</span><br/>
+                                        <span th:text="${oldCustomer.getName()}"></span> transferred a ticket to you. In this email you find a newly generated barcode.
+                                        <br/>
+                                        <br/>
+                                    </td>
+                                </tr>
+                            </table>
+
+
+                            <table class="force-full-width" cellspacing="0" cellpadding="30" bgcolor="#ebebeb"
+                                   style="border-collapse: collapse !important;width: 100% !important;">
+                                <tr>
+                                    <td class="mobile-block" width="325"
+                                        style="font-family: Arial, sans-serif;color: #5e5e5e;font-size: 16px;text-align: left;border-collapse: collapse;">
+                                        <table cellspacing="0" cellpadding="0" width="100%"
+                                               style="border-collapse: collapse !important;">
+                                            <tr>
+                                                <td>
+                                                    <h3>Ticket overview</h3>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td style="font-family: Arial, sans-serif;color: #5e5e5e;font-size: 16px;text-align: left;border-collapse: collapse;">
+                                                    <table cellspacing="0" cellpadding="0" width="100%"
+                                                           style="border-collapse: collapse !important;">
+                                                        <tr>
+                                                            <td class="grey-header"
+                                                                style="font-family: Arial, sans-serif;color: #5e5e5e;font-size: 16px;text-align: left;border-collapse: collapse;background-color: #dedede;padding: 5px;font-weight: bold;">
+                                                                Description
+                                                            </td>
+                                                            <td class="grey-header"
+                                                                style="font-family: Arial, sans-serif;color: #5e5e5e;font-size: 16px;text-align: left;border-collapse: collapse;background-color: #dedede;padding: 5px;font-weight: bold;">
+                                                                Barcode
+                                                            </td>
+                                                        </tr>
+                                                        <tr>
+                                                            <td class="white-header"
+                                                                th:text="${ticket.getProduct().getTitle()}"
+                                                                style="font-family: Arial, sans-serif;color: #5e5e5e;font-size: 16px;text-align: left;border-collapse: collapse;background-color: #f3f3f3;padding: 5px;">
+                                                                T.U.E.S.DAY
+                                                            </td>
+                                                            <td class="white-header"
+                                                                style="font-family: Arial, sans-serif;color: #5e5e5e;font-size: 16px;text-align: left;border-collapse: collapse;background-color: #f3f3f3;padding: 5px;">
+                                                                <img th:src="${'cid:ch-' + ticket.getUniqueCode() + '.png'}"
+                                                                     width="226px"
+                                                                     class="barcode" alt="">
+                                                            </td>
+                                                        </tr>
+                                                    </table>
+                                                    &nbsp;<table th:if="${redirectLink}" cellspacing="0" cellpadding="0" width="100%"
+                                                                 style="border-collapse: collapse !important;">
+                                                    <tr>
+                                                        <td>
+                                                            <h3>Form links for your ticket!</h3>
+                                                        </td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td style="font-family: Arial, sans-serif;color: #5e5e5e;font-size: 16px;text-align: left;border-collapse: collapse;">
+                                                            <table cellspacing="0"
+                                                                   cellpadding="0" width="100%"
+                                                                   style="border-collapse: collapse !important;">
+                                                                <tr>
+                                                                    <td style="font-family: Arial, sans-serif;color: #5e5e5e;font-size: 16px;text-align: left;border-collapse: collapse;">
+                                                                        <table cellspacing="0" cellpadding="0"
+                                                                               width="100%"
+                                                                               style="border-collapse: collapse !important;">
+                                                                            <tr>
+                                                                                <td class="grey-header"
+                                                                                    style="font-family: Arial, sans-serif;color: #5e5e5e;font-size: 16px;text-align: left;border-collapse: collapse;background-color: #dedede;padding: 5px;font-weight: bold;">
+                                                                                    Description
+                                                                                </td>
+                                                                                <td class="grey-header"
+                                                                                    style="font-family: Arial, sans-serif;color: #5e5e5e;font-size: 16px;text-align: left;border-collapse: collapse;background-color: #dedede;padding: 5px;font-weight: bold;">
+                                                                                    Link
+                                                                                </td>
+                                                                            </tr>
+                                                                            <tr>
+                                                                                <td class="white-header"
+                                                                                    th:text="${ticket.getProduct().getTitle()}"
+                                                                                    style="font-family: Arial, sans-serif;color: #5e5e5e;font-size: 16px;text-align: left;border-collapse: collapse;background-color: #f3f3f3;padding: 5px;">
+                                                                                </td>
+                                                                                <td class="white-header"
+                                                                                    style="font-family: Arial, sans-serif;color: #5e5e5e;font-size: 16px;text-align: left;border-collapse: collapse;background-color: #f3f3f3;padding: 5px;">
+                                                                                    <a th:href="${ticket.getProduct().getRedirectUrl()}"
+                                                                                       th:text="${ticket.getProduct().getRedirectUrl()}"></a>
+                                                                                </td>
+                                                                            </tr>
+                                                                        </table>
+                                                                        &nbsp;
+                                                                    </td>
+                                                                </tr>
+                                                            </table>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <table class="force-full-width" cellspacing="0" cellpadding="20" bgcolor="#1E274A"
+                                   style="border-collapse: collapse !important;width: 100% !important;">
+                                <tr>
+                                    <td style="background-color: #1E274A;color: #ffffff;font-size: 14px;text-align: center;font-family: Arial, sans-serif;border-collapse: collapse;">
+                                        This mail was automatically generated by CH Events.
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+            </center>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/src/main/resources/templates/webshop/overview/index.html
+++ b/src/main/resources/templates/webshop/overview/index.html
@@ -220,6 +220,10 @@
                                                        class="btn btn-primary btn-block">
                                                         <span>Fill in the form!</span>
                                                     </a>
+                                                    <a th:href="@{'/tickets/'+ ${ticket.getKey()}+'/transfer'}"
+                                                       class="btn btn-outline-primary btn-block">
+                                                        <span>Transfer ticket</span>
+                                                    </a>
                                                     <button type="button" class="btn btn-secondary btn-block"
                                                             data-dismiss="modal">Close
                                                     </button>

--- a/src/main/resources/templates/webshop/overview/index.html
+++ b/src/main/resources/templates/webshop/overview/index.html
@@ -221,7 +221,7 @@
                                                         <span>Fill in the form!</span>
                                                     </a>
                                                     <a th:href="@{'/tickets/'+ ${ticket.getKey()}+'/transfer'}"
-                                                       class="btn btn-outline-primary btn-block">
+                                                       class="btn btn-danger btn-block">
                                                         <span>Transfer ticket</span>
                                                     </a>
                                                     <button type="button" class="btn btn-secondary btn-block"

--- a/src/main/resources/templates/webshop/overview/index.html
+++ b/src/main/resources/templates/webshop/overview/index.html
@@ -43,6 +43,7 @@
             </a>
         </div>
     </div>
+    <div th:replace="fragments/messages :: messages"></div>
 
     <div class="row">
         <div class="col-12 col-lg-3 mb-5">

--- a/src/main/resources/templates/webshop/overview/index.html
+++ b/src/main/resources/templates/webshop/overview/index.html
@@ -220,7 +220,7 @@
                                                        class="btn btn-primary btn-block">
                                                         <span>Fill in the form!</span>
                                                     </a>
-                                                    <a th:href="@{'/tickets/'+ ${ticket.getKey()}+'/transfer'}"
+                                                    <a th:if="${ticket.canTransfer(ticket.getOwner(), null, null)}" th:href="@{'/tickets/'+ ${ticket.getKey()}+'/transfer'}"
                                                        class="btn btn-danger btn-block">
                                                         <span>Transfer ticket</span>
                                                     </a>

--- a/src/main/resources/templates/webshop/tickets/transfer.html
+++ b/src/main/resources/templates/webshop/tickets/transfer.html
@@ -43,7 +43,7 @@
             </a>
         </div>
     </div>
-
+    <div th:replace="fragments/messages :: messages"></div>
     <div class="row">
         <div class="col-6 col-lg-4">
             <div class="card">

--- a/src/main/resources/templates/webshop/tickets/transfer.html
+++ b/src/main/resources/templates/webshop/tickets/transfer.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <!-- Icons -->
+    <link rel="apple-touch-icon" sizes="180x180" th:href="@{/icons/apple-touch-icon.png}">
+    <link rel="icon" type="image/png" sizes="32x32" th:href="@{/icons/favicon-32x32.png}">
+    <link rel="icon" type="image/png" sizes="16x16" th:href="@{/icons/favicon-16x16.png}">
+    <link rel="manifest" th:href="@{/icons/site.webmanifest}">
+    <link rel="mask-icon" th:href="@{/icons/safari-pinned-tab.svg}" color="#1e274a">
+    <link rel="shortcut icon" th:href="@{/icons/favicon.ico}">
+    <meta name="msapplication-TileColor" content="#2b5797">
+    <meta name="msapplication-config" th:content="@{/icons/browserconfig.xml}">
+    <meta name="theme-color" content="#ffffff">
+
+    <title>CH Events</title>
+
+    <!--Bootstrap core CSS -->
+    <link th:href="@{/webjars/wisvch-bootstrap-theme/dist/css/bootstrap.min.css}" rel="stylesheet">
+    <link rel="stylesheet" href="https://use.typekit.net/uet5duo.css">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+    <link th:href="@{/css/wisvch-dashboard.css}" rel="stylesheet">
+    <link th:href="@{/css/wisvch-header.css}" rel="stylesheet">
+    <link th:href="@{/css/wisvch-overview.css}" rel="stylesheet">
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.5.2/animate.min.css">
+    <link rel="stylesheet" th:href="@{/webjars/font-awesome/5.0.13/web-fonts-with-css/css/fontawesome-all.min.css}">
+</head>
+
+<body>
+<nav th:replace="webshop/fragments/header :: header ('my events', 'events_header.jpg')"></nav>
+
+<div class="container-fluid">
+    <div class="row pt-5">
+        <div class="mr-auto col-lg-4 col-md-5 col-12 mb-4">
+            <a th:href="@{/}" class="btn btn-block btn-primary">
+                <i class="fas fa-arrow-left"></i> Back to the webshop
+            </a>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-6 col-lg-4">
+            <div class="card">
+                <h6 class="card-header">Transfer ticket</h6>
+                <div class="card-body">
+                    <div class="row">
+                        <div class="col-12 col-lg-6">
+                            <h4>
+                                [[${ticket.getProduct().getTitle()}]]
+                            </h4>
+                            <p>Transfer this ticket to another person. Note that <b>this action cannot be undone.</b></p>
+                        </div>
+                        <div class="col-12 col-lg-6 text-center mb-4">
+                            <img class="img-fluid" th:src="'https://barcode.tec-it.com/barcode.ashx?data=280433' + ${ticket.getUniqueCode()} + '&code=EAN13&multiplebarcodes=false&translate-esc=false&unit=Fit&dpi=128&imagetype=Gif&rotation=0&color=%23000000&bgcolor=%23FFFFFF&qunit=Mm&quiet=0'">
+                        </div>
+                    </div>
+                    <form th:action="@{'./transfer'}" method="POST">
+                        <div class="row">
+                            <div class="col-12">
+                                <div class="form-group">
+                                    <input type="email" class="form-control input-lg" name="email"
+                                           placeholder="Email address">
+                                    <small class="form-text text-muted">
+                                        Fill in the email address of the person you want to transfer the ticket to. This person must already have an account on the webshop.
+                                    </small>
+                                </div>
+
+                                <button type="submit" class="btn btn-block btn-danger">Transfer</button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
+<script th:src="@{/webjars/bootstrap/4.0.0-beta/js/bootstrap.min.js}"></script>
+</body>
+

--- a/src/test/java/ch/wisv/events/core/service/TicketServiceTest.java
+++ b/src/test/java/ch/wisv/events/core/service/TicketServiceTest.java
@@ -9,6 +9,7 @@ import ch.wisv.events.core.model.product.Product;
 import ch.wisv.events.core.model.ticket.Ticket;
 import ch.wisv.events.core.model.ticket.TicketStatus;
 import ch.wisv.events.core.repository.TicketRepository;
+import ch.wisv.events.core.service.mail.MailService;
 import ch.wisv.events.core.service.ticket.TicketService;
 import ch.wisv.events.core.service.ticket.TicketServiceImpl;
 import com.google.common.collect.ImmutableList;
@@ -39,6 +40,10 @@ public class TicketServiceTest extends ServiceTest {
     @Mock
     private TicketRepository ticketRepository;
 
+    /** MailService. */
+    @Mock
+    private MailService mailService;
+
     /** TicketService. */
     private TicketService ticketService;
 
@@ -56,7 +61,7 @@ public class TicketServiceTest extends ServiceTest {
      */
     @Before
     public void setUp() {
-        ticketService = new TicketServiceImpl(ticketRepository);
+        ticketService = new TicketServiceImpl(ticketRepository, mailService);
 
         ticket1 = new Ticket();
         ticket2 = new Ticket();

--- a/src/test/java/ch/wisv/events/core/service/TicketServiceTest.java
+++ b/src/test/java/ch/wisv/events/core/service/TicketServiceTest.java
@@ -9,6 +9,7 @@ import ch.wisv.events.core.model.product.Product;
 import ch.wisv.events.core.model.ticket.Ticket;
 import ch.wisv.events.core.model.ticket.TicketStatus;
 import ch.wisv.events.core.repository.TicketRepository;
+import ch.wisv.events.core.service.event.EventService;
 import ch.wisv.events.core.service.mail.MailService;
 import ch.wisv.events.core.service.ticket.TicketService;
 import ch.wisv.events.core.service.ticket.TicketServiceImpl;
@@ -40,6 +41,10 @@ public class TicketServiceTest extends ServiceTest {
     @Mock
     private TicketRepository ticketRepository;
 
+    @Mock
+    /** EventService. */
+    private EventService eventService;
+
     /** MailService. */
     @Mock
     private MailService mailService;
@@ -61,7 +66,7 @@ public class TicketServiceTest extends ServiceTest {
      */
     @Before
     public void setUp() {
-        ticketService = new TicketServiceImpl(ticketRepository, mailService);
+        ticketService = new TicketServiceImpl(ticketRepository, eventService, mailService);
 
         ticket1 = new Ticket();
         ticket2 = new Ticket();

--- a/src/test/java/ch/wisv/events/core/service/TicketTransferTest.java
+++ b/src/test/java/ch/wisv/events/core/service/TicketTransferTest.java
@@ -1,0 +1,166 @@
+package ch.wisv.events.core.service;
+
+import ch.wisv.events.ServiceTest;
+import ch.wisv.events.core.exception.normal.TicketNotTransferableException;
+import ch.wisv.events.core.model.customer.Customer;
+import ch.wisv.events.core.model.product.Product;
+import ch.wisv.events.core.model.ticket.Ticket;
+import ch.wisv.events.core.model.ticket.TicketStatus;
+import ch.wisv.events.core.repository.TicketRepository;
+import ch.wisv.events.core.service.auth.AuthenticationService;
+import ch.wisv.events.core.service.customer.CustomerService;
+import ch.wisv.events.core.service.ticket.TicketService;
+import ch.wisv.events.core.service.ticket.TicketServiceImpl;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import static org.mockito.Mockito.when;
+
+/**
+ * TicketService test.
+ */
+public class TicketTransferTest extends ServiceTest {
+
+    /** Mock of TicketRepository. */
+    @Mock
+    private TicketRepository ticketRepository;
+
+    /** CustomerService. */
+    @Mock
+    private CustomerService customerService;
+
+    /** TicketService. */
+    private TicketService ticketService;
+
+    /** AuthenticationService. */
+    @Mock
+    private AuthenticationService authenticationService;
+
+    /** Tickets. */
+    private Ticket ticket1, ticket2, ticket3;
+
+    /** Product. */
+    private Product product1, product2;
+
+    /** Customers. */
+    private Customer customer1, customer2, customer3;
+
+    /**
+     * Setup for the test class.
+     */
+    @Before
+    public void setUp() {
+        ticketService = new TicketServiceImpl(ticketRepository);
+
+        customer1 = new Customer();
+        customer1.setVerifiedChMember(true);
+
+        customer2 = new Customer();
+        customer3 = new Customer();
+
+
+        product1 = new Product();
+        product2 = new Product();
+        product2.setChOnly(true);
+
+        ticket1 = new Ticket();
+        ticket1.setOwner(customer1);
+        ticket1.setProduct(product1);
+        ticket1.setUniqueCode("uniqueCode1");
+        ticket1.setStatus(TicketStatus.OPEN);
+        ticket1.setValid(true);
+
+        ticket2 = new Ticket();
+        ticket2.setOwner(customer2);
+        ticket2.setProduct(product2);
+        ticket2.setUniqueCode("uniqueCode2");
+        ticket2.setStatus(TicketStatus.SCANNED);
+        ticket1.setValid(true);
+
+        // Set current customer to customer1
+        Mockito.when(authenticationService.getCurrentCustomer()).thenReturn(customer1);
+    }
+
+    /**
+     * Test ticket transfer to another customer.
+     */
+    @Test
+    public void transferTicket() {
+
+        when(ticketRepository.findById(any(Integer.class))).thenReturn(Optional.of(ticket1));
+        when(ticketRepository.saveAndFlush(any(Ticket.class))).thenReturn(ticket1);
+
+        String uniqueCode = ticket1.getUniqueCode();
+
+        try {
+            ticketService.transfer(ticket1, customer1, customer2);
+        } catch (TicketNotTransferableException e) {
+            fail("Should not have thrown any exception");
+        }
+
+        // Check if customer2 is new owner
+        assertEquals(customer2, ticket1.getOwner());
+
+        // Check if unique code is changed
+        assertNotEquals(uniqueCode, ticket1.getUniqueCode());
+    }
+
+    /**
+     * Test ticket transfer of scanned ticket.
+     */
+    @Test
+    public void transferScannedTicket() {
+
+        when(ticketRepository.findById(any(Integer.class))).thenReturn(Optional.of(ticket2));
+        when(ticketRepository.saveAndFlush(any(Ticket.class))).thenReturn(ticket2);
+
+        TicketNotTransferableException thrown = assertThrows(TicketNotTransferableException.class, () -> ticketService.transfer(ticket2, customer1, customer2));
+        assert(thrown.getMessage().contains("Ticket is already scanned."));
+
+    }
+
+    /**
+     * Test ticket transfer of invalid ticket.
+     */
+    @Test
+    public void transferInvalidTicket() {
+        ticket1.setValid(false);
+
+        TicketNotTransferableException thrown = assertThrows(TicketNotTransferableException.class, () -> ticketService.transfer(ticket1, customer1, customer2));
+        assert (thrown.getMessage().contains("Ticket is not valid."));
+    }
+
+    /**
+     * Test transferring ChOnly ticket to customer that is not a verified Ch member.
+     */
+    @Test
+    public void transferChOnlyTicket() {
+        ticket1.setProduct(product2);
+
+        TicketNotTransferableException thrown = assertThrows(TicketNotTransferableException.class, () -> ticketService.transfer(ticket1, customer1, customer2));
+        assert (thrown.getMessage().contains("Ticket can only be transferred to a verified CH member."));
+    }
+
+    /**
+     * Test transferring a ticket that is now owned by the current customer.
+     */
+    @Test
+    public void transferNotOwnedTicket() {
+        TicketNotTransferableException thrown = assertThrows(TicketNotTransferableException.class, () -> ticketService.transfer(ticket1, customer2, customer1));
+        assert (thrown.getMessage().contains("Ticket can only be transferred to the owner."));
+    }
+
+    /**
+     * Test transferring a ticket that is already owned by the current customer.
+     */
+    @Test
+    public void transferSelfTicket() {
+        TicketNotTransferableException thrown = assertThrows(TicketNotTransferableException.class, () -> ticketService.transfer(ticket1, customer1, customer1));
+        assert (thrown.getMessage().contains("Sadly you can not transfer a ticket to yourself.."));
+    }
+}

--- a/src/test/java/ch/wisv/events/webshop/controller/WebshopCustomerControllerTest.java
+++ b/src/test/java/ch/wisv/events/webshop/controller/WebshopCustomerControllerTest.java
@@ -43,6 +43,19 @@ public class WebshopCustomerControllerTest extends ControllerTest {
                 .andExpect(content().string(containsString("href=\"/checkout/" + order.getPublicReference() + "/customer/guest\"")));
     }
 
+    /**
+     * Customer chconnect tests
+     */
+    @Test
+    public void testCustomerChconnectOptions() throws Exception {
+        Order order = this.createOrder(null, new ArrayList<>(), OrderStatus.ANONYMOUS, "events-webshop");
+
+        // Expect redirect to chconnect
+        mockMvc.perform(get("/checkout/" + order.getPublicReference() + "/customer"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/checkout/" + order.getPublicReference() + "/customer/chconnect"));
+    }
+
     @Test
     public void testCustomerOptionsNotAnonymous() throws Exception {
         Order order = this.createOrder(null, new ArrayList<>(), OrderStatus.ASSIGNED, "events-webshop");

--- a/src/test/java/ch/wisv/events/webshop/controller/WebshopCustomerControllerTest.java
+++ b/src/test/java/ch/wisv/events/webshop/controller/WebshopCustomerControllerTest.java
@@ -35,27 +35,12 @@ public class WebshopCustomerControllerTest extends ControllerTest {
     public void testCustomerOptions() throws Exception {
         Order order = this.createOrder(null, new ArrayList<>(), OrderStatus.ANONYMOUS, "events-webshop");
 
-        // Logout
-        mockMvc.perform(post("/logout"));
         mockMvc.perform(get("/checkout/" + order.getPublicReference() + "/customer"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("webshop/checkout/customer"))
                 .andExpect(model().attribute("order", order))
                 .andExpect(content().string(containsString("href=\"/checkout/" + order.getPublicReference() + "/customer/chconnect\"")))
                 .andExpect(content().string(containsString("href=\"/checkout/" + order.getPublicReference() + "/customer/guest\"")));
-    }
-
-    /**
-     * Customer chconnect tests
-     */
-    @Test
-    public void testCustomerChconnectOptions() throws Exception {
-        Order order = this.createOrder(null, new ArrayList<>(), OrderStatus.ANONYMOUS, "events-webshop");
-
-        // Expect redirect to chconnect
-        mockMvc.perform(get("/checkout/" + order.getPublicReference() + "/customer"))
-                .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl("/checkout/" + order.getPublicReference() + "/customer/chconnect"));
     }
 
     @Test

--- a/src/test/java/ch/wisv/events/webshop/controller/WebshopCustomerControllerTest.java
+++ b/src/test/java/ch/wisv/events/webshop/controller/WebshopCustomerControllerTest.java
@@ -35,6 +35,8 @@ public class WebshopCustomerControllerTest extends ControllerTest {
     public void testCustomerOptions() throws Exception {
         Order order = this.createOrder(null, new ArrayList<>(), OrderStatus.ANONYMOUS, "events-webshop");
 
+        // Logout
+        mockMvc.perform(post("/logout"));
         mockMvc.perform(get("/checkout/" + order.getPublicReference() + "/customer"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("webshop/checkout/customer"))


### PR DESCRIPTION
This commit makes it possible to transfer tickets to other customers. This can be used when you sell your ticket to somebody, or when you bought tickets for a whole group and want to distribute them.

- [x] Add ticket transfer form.
- [x] Generate a new barcode after transferring.
- [x] Only allow transferring CH Only tickets to CH Only customers.
- [x] Send email to receiving customer.
- [x] Test the code using automated testing.

Optionally
- [ ] Indicate ticket as transferred on customers profile.
- [ ] Add logging to tickets to take track of where tickets are transferred to.
- [x] Only allow the transfer of tickets for events in the future, to prevent spam.
- [ ] Allow admins to transfer every ticket.