### PR TITLE
Feature/scanned progress

### DIFF
--- a/src/main/java/ch/wisv/events/admin/controller/DashboardEventController.java
+++ b/src/main/java/ch/wisv/events/admin/controller/DashboardEventController.java
@@ -1,5 +1,6 @@
 package ch.wisv.events.admin.controller;
 
+import ch.wisv.events.core.admin.Attendence;
 import ch.wisv.events.core.exception.normal.EventInvalidException;
 import ch.wisv.events.core.exception.normal.EventNotFoundException;
 import ch.wisv.events.core.model.event.Event;
@@ -247,7 +248,7 @@ public class DashboardEventController extends DashboardController {
 
             model.addAttribute(OBJ_EVENT, event);
             model.addAttribute(OBJ_TICKETS, tickets);
-
+            model.addAttribute("attendance", eventService.getAttendance(event));
             return "admin/events/overview";
         } catch (EventNotFoundException e) {
             redirect.addFlashAttribute(FLASH_ERROR, e.getMessage());

--- a/src/main/java/ch/wisv/events/admin/controller/DashboardIndexController.java
+++ b/src/main/java/ch/wisv/events/admin/controller/DashboardIndexController.java
@@ -116,25 +116,6 @@ public class DashboardIndexController extends DashboardController {
     }
 
     /**
-     * Method determineAttendanceRateEvent ...
-     *
-     * @param event of type Event
-     *
-     * @return double
-     */
-    private double determineAttendanceRateEvent(Event event) {
-        List<Ticket> eventTickets = event.getProducts().stream().flatMap(product -> ticketService.getAllByProduct(product).stream()).collect(
-                Collectors.toList());
-        long numberTicketsScanned = eventTickets.stream().filter(ticket -> ticket.getStatus() == TicketStatus.SCANNED).count();
-
-        if (eventTickets.size() == 0) {
-            return 0.d;
-        }
-
-        return Math.round(numberTicketsScanned / (eventTickets.size() * 10000.d)) / 100.d;
-    }
-
-    /**
      * Method determinePreviousEventAttendance ...
      *
      * @return HashMap
@@ -142,7 +123,7 @@ public class DashboardIndexController extends DashboardController {
     private HashMap<Event, Double> determinePreviousEventAttendance() {
         HashMap<Event, Double> events = new HashMap<>();
 
-        this.eventService.getPreviousEventsLastTwoWeeks().forEach(event -> events.put(event, this.determineAttendanceRateEvent(event)));
+        this.eventService.getPreviousEventsLastTwoWeeks().forEach(event -> events.put(event, eventService.getAttendance(event).getPercentageScanned()));
 
         return events;
     }

--- a/src/main/java/ch/wisv/events/core/admin/Attendence.java
+++ b/src/main/java/ch/wisv/events/core/admin/Attendence.java
@@ -3,5 +3,6 @@ package ch.wisv.events.core.admin;
 
 public interface Attendence {
     long getTicketsCount();
+    long getScannedCount();
     double getPercentageScanned();
 }

--- a/src/main/java/ch/wisv/events/core/repository/EventRepository.java
+++ b/src/main/java/ch/wisv/events/core/repository/EventRepository.java
@@ -87,7 +87,7 @@ public interface EventRepository extends JpaRepository<Event, Integer> {
     Optional<Event> findByProductsContaining(Product product);
 
     @Query(value =
-            "select count(*) as ticketsCount, avg(status)*100 as percentageScanned " +
+            "select count(*) as ticketsCount, sum(status) as scannedCount, avg(status)*100 as percentageScanned " +
                     "from Ticket A INNER JOIN (Select distinct products_id FROM ticket T1 INNER JOIN (Select products_id from " +
                     "event_products EP INNER JOIN " +
                     "(Select id from event e where e.ending between :startDate and :endDate) E " +

--- a/src/main/java/ch/wisv/events/core/repository/EventRepository.java
+++ b/src/main/java/ch/wisv/events/core/repository/EventRepository.java
@@ -94,4 +94,13 @@ public interface EventRepository extends JpaRepository<Event, Integer> {
                     "ON E.id=EP.event_id) T2 ON T1.product_id=T2.products_id) B " +
                     "ON A.product_id=B.products_id;", nativeQuery = true) //TODO fix proper date
     Attendence getAttendenceFromEventsInDateRange(@Param("startDate") LocalDateTime start, @Param("endDate") LocalDateTime End);
+
+    @Query(value =
+            "select count(*) as ticketsCount, coalesce(sum(status), 0) as scannedCount, coalesce(avg(status),0 ) * 100 as percentageScanned " +
+                    "from Ticket A INNER JOIN (Select distinct products_id FROM ticket T1 INNER JOIN (Select products_id from " +
+                    "event_products EP INNER JOIN " +
+                    "(Select :event_id as id) E " +
+                    "ON E.id=EP.event_id) T2 ON T1.product_id=T2.products_id) B " +
+                    "ON A.product_id=B.products_id;", nativeQuery = true)
+    Attendence getAttendanceFromEvent(@Param("event_id") Integer event_id);
 }

--- a/src/main/java/ch/wisv/events/core/service/event/EventService.java
+++ b/src/main/java/ch/wisv/events/core/service/event/EventService.java
@@ -1,5 +1,6 @@
 package ch.wisv.events.core.service.event;
 
+import ch.wisv.events.core.admin.Attendence;
 import ch.wisv.events.core.exception.normal.EventInvalidException;
 import ch.wisv.events.core.exception.normal.EventNotFoundException;
 import ch.wisv.events.core.model.document.Document;
@@ -117,4 +118,11 @@ public interface EventService {
      */
     void addDocumentImage(Event event, Document document);
 
+    /**
+     * Get attendance by Event
+     *
+     * @param event Event
+     * @return Attendance of event
+     */
+    Attendence getAttendance(Event event);
 }

--- a/src/main/java/ch/wisv/events/core/service/event/EventServiceImpl.java
+++ b/src/main/java/ch/wisv/events/core/service/event/EventServiceImpl.java
@@ -1,5 +1,6 @@
 package ch.wisv.events.core.service.event;
 
+import ch.wisv.events.core.admin.Attendence;
 import ch.wisv.events.core.exception.normal.EventInvalidException;
 import ch.wisv.events.core.exception.normal.EventNotFoundException;
 import ch.wisv.events.core.exception.normal.ProductInvalidException;
@@ -207,6 +208,17 @@ public class EventServiceImpl implements EventService {
     @Override
     public void addDocumentImage(Event event, Document document) {
         event.setImageUrl(this.imageLocation + document.getFileName() + ".png");
+    }
+
+    /**
+     * Get attendance by Event
+     *
+     * @param event Event
+     * @return Attendance of event
+     */
+    @Override
+    public Attendence getAttendance(Event event) {
+        return eventRepository.getAttendanceFromEvent(event.getId());
     }
 
     /**

--- a/src/main/resources/static/css/wisvch-dashboard.css
+++ b/src/main/resources/static/css/wisvch-dashboard.css
@@ -338,7 +338,6 @@ h1 .badge-info {
 }
 
 .progress .progress-bar {
-    height: 30px;
     background-color: #2AA1A9;
     line-height: 30px;
     padding-left: .25rem;

--- a/src/main/resources/templates/admin/events/overview.html
+++ b/src/main/resources/templates/admin/events/overview.html
@@ -65,7 +65,6 @@
                                      aria-valuemin="0" aria-valuemax="100"
                                      th:style="'width: ' + ${attendance.getPercentageScanned()} + '%;'"
                                      th:text="${attendance.getPercentageScanned()} + '%'">
-                                    59%
                                 </div>
                             </div>
                         </div>

--- a/src/main/resources/templates/admin/events/overview.html
+++ b/src/main/resources/templates/admin/events/overview.html
@@ -45,9 +45,31 @@
 
             <div th:replace="fragments/messages :: messages"></div>
 
-            <div class="row  my-2">
+            <div class="row mb-4">
                 <div class="col-auto">
                     <a th:href="@{'/administrator/events/overview/csv/' + ${event.getKey()} + '/'}" class="btn btn-secondary btn-block">export to csv</a>
+                </div>
+            </div>
+
+            <div class="row">
+                <div class="col">
+                    <div class="card mb-4">
+                        <h6 class="card-header">Scanned Tickets</h6>
+                        <div class="card-body text-primary">
+                            <h4 class="card-title">
+                                [[${attendance.getScannedCount()}]] <small>out of [[${attendance.getTicketsCount()}]]</small>
+                            </h4>
+                            <div class="progress mb-2">
+                                <div class="progress-bar" role="progressbar"
+                                     th:aria-valuenow="${attendance.getPercentageScanned()}"
+                                     aria-valuemin="0" aria-valuemax="100"
+                                     th:style="'width: ' + ${attendance.getPercentageScanned()} + '%;'"
+                                     th:text="${attendance.getPercentageScanned()} + '%'">
+                                    59%
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
This PR does the following:
- Remove the old way of calculating attendance, replacing it with an SQL query and using the `Attendence` class. (This also fixes the 'Previous events' - 'Attendance rate' not working on the overview in the admin dashboard.
- Add a progress bar for scanned tickets on the events' overview page.
- Fix the styling of the progress bars so that the text in the bar is visible.

it looks like this:

<img width="393" alt="Scherm­afbeelding 2023-09-30 om 12 43 01" src="https://github.com/WISVCH/events/assets/13507227/cc765224-62f7-480c-a81c-fd87e8f1eb45">

<img width="2112" alt="Scherm­afbeelding 2023-09-30 om 12 43 32" src="https://github.com/WISVCH/events/assets/13507227/4940fa05-a907-43cd-8d36-233ca676041c">
