### PR TITLE
Fix/logo size

### DIFF
--- a/src/main/resources/static/css/wisvch-header.css
+++ b/src/main/resources/static/css/wisvch-header.css
@@ -47,15 +47,38 @@ body.menu-open .page-header {
     background-color: #ffffff;
 }
 
-@media (max-width: 991px){
-    .navbar-collapse {
-        padding-top: 3rem;
+.navbar-brand {
+    transform: translateY(30px);
+    margin-top: -30px;
+    margin-left: .5rem;
+}
+
+.navbar-brand img{
+    max-height: 4rem;
+}
+
+@media screen and (max-width: 500px) {
+    .navbar-brand {
+        transform: translateY(0);
+        margin-top: 0;
+        margin-left: 0;
+    }
+
+    .navbar-brand img{
+        max-height: 3rem;
     }
 }
 
-.navbar .logo img {
-    margin: .5rem;
-    height: 4rem;
+@media screen and (max-width: 370px) {
+    .navbar-brand img{
+        max-height: 2rem;
+    }
+}
+
+@media screen and (max-width: 1200px) and (min-width: 500px) {
+    .navbar-collapse {
+        padding-top: 2.5rem;
+    }
 }
 
 .wisv-header.header-left {

--- a/src/main/resources/templates/webshop/event.html
+++ b/src/main/resources/templates/webshop/event.html
@@ -38,10 +38,10 @@
 
     <!-- Top Bar -->
     <div class="wisv-header header-left">
-        <nav class="navbar navbar-expand-lg navbar-light wisv-header-bg">
-            <a class="logo" href="https://ch.tudelft.nl/">
-                <img src="https://ch.tudelft.nl/wp-content/themes/rechallenge/assets/images/ch-logo.png"
-                     alt="W.I.S.V. 'Christiaan Huygens'">
+        <nav class="navbar navbar-expand-xl navbar-light wisv-header-bg">
+            <a class="navbar-brand" href="https://ch.tudelft.nl/">
+                <img th:src=@{'/images/ch-logo.png'}
+                     alt="W.I.S.V. 'Christiaan Huygens'" >
             </a>
 
             <button class="navbar-toggler btn btn-secondary" type="button" data-toggle="collapse"

--- a/src/main/resources/templates/webshop/fragments/header.html
+++ b/src/main/resources/templates/webshop/fragments/header.html
@@ -5,10 +5,10 @@
 <header class="page-header" th:fragment="header (title, image)">
     <!-- Top Bar -->
     <div class="wisv-header header-left">
-        <nav class="navbar navbar-expand-lg navbar-light wisv-header-bg">
-            <a class="logo" href="https://ch.tudelft.nl/">
+        <nav class="navbar navbar-expand-xl navbar-light wisv-header-bg">
+            <a class="navbar-brand" href="https://ch.tudelft.nl/">
                 <img th:src=@{'/images/ch-logo.png'}
-                     alt="W.I.S.V. 'Christiaan Huygens'" style="position: absolute; top: 10px;">
+                     alt="W.I.S.V. 'Christiaan Huygens'" >
             </a>
 
             <button class="navbar-toggler btn btn-secondary" type="button" data-toggle="collapse"


### PR DESCRIPTION
This PR makes the logo in the header smaller, so that it doesn't cover up the menu buttons on mobile.

Before:

![before](https://github.com/WISVCH/events/assets/13507227/df8b9c9c-e842-4b57-b34e-8f133183e124)

After:

![after](https://github.com/WISVCH/events/assets/13507227/ed4cd284-2412-4862-9a47-1d93417f0d5a)