### PR TITLE
Made Sales Export Tab that replaces the Treasurer Tab

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'com.tngtech.java:junit-dataprovider:1.5.0'
+
+    implementation 'org.javatuples:javatuples:1.2'
 }
 
 jacocoTestReport {

--- a/src/main/java/ch/wisv/events/admin/controller/DashboardSalesexportController.java
+++ b/src/main/java/ch/wisv/events/admin/controller/DashboardSalesexportController.java
@@ -1,0 +1,157 @@
+package ch.wisv.events.admin.controller;
+
+import ch.wisv.events.core.model.order.PaymentMethod;
+import ch.wisv.events.core.admin.TreasurerData;
+import ch.wisv.events.core.admin.SalesexportSubmission;
+import ch.wisv.events.utils.LdapGroup;
+
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.io.InputStream;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import com.google.common.collect.Lists;
+
+import ch.wisv.events.core.repository.OrderRepository;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.apache.commons.lang3.tuple.Triple;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.javatuples.Septet;
+
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+
+/**
+ * DashboardSalesexportController class.
+ */
+@Controller
+@RequestMapping("/administrator/salesexport")
+@PreAuthorize("hasRole('ADMIN')")
+public class DashboardSalesexportController extends DashboardController {
+
+    /** TreasurerRepository */
+    private final OrderRepository orderRepository;
+
+    /**
+     * DashboardSalesexportController constructor.
+     *
+     * @param orderRepository of type OrderRepository
+     */
+    @Autowired
+    public DashboardSalesexportController(OrderRepository orderRepository) {
+        this.orderRepository = orderRepository;
+    }
+
+    /**
+     * Index of vendor [GET "/"].
+     *
+     * @param model String model
+     *
+     * @return path to Thymeleaf template location
+     */
+    @GetMapping
+    public String index(Model model) {
+        // model.addAttribute("productMap", this.generateProductMap());
+        model.addAttribute("SalesexportSubmission", new SalesexportSubmission());
+
+        return "admin/salesexport/index";
+    }
+
+    
+    
+    /**
+     * Exports sales of month to csv
+     * 
+     */
+    @GetMapping(value="/csv", produces="text/csv")
+    public HttpEntity<? extends Object> csvExport(@ModelAttribute SalesexportSubmission SalesexportSubmission, Model model) {
+        model.addAttribute("SalesexportSubmission", SalesexportSubmission);
+        
+        // Convert payment methods to integers
+        List<Integer> paymentMethods = new ArrayList<>();
+        SalesexportSubmission.getIncludedPaymentMethods().forEach( (m) -> paymentMethods.add(m.toInt()) );
+
+        List<TreasurerData> treasurerData = orderRepository.findallPaymentsByMonth(SalesexportSubmission.getMonth(), SalesexportSubmission.getYear(), paymentMethods, SalesexportSubmission.isFreeProductsIncluded());
+        
+        ListIterator<TreasurerData> listIterator = treasurerData.listIterator(treasurerData.size());
+        
+        // Loop through all orders in TreasurerData and add orders of the same product together
+
+        // Key: Product ID, Value: Septet with: event title, organized by, product title, total income, amount, vatRate, price
+        Map<Integer, Septet<String, Integer, String, Double, Integer, String, Double>> map = new HashMap<>();
+        
+        while (listIterator.hasPrevious()) {
+            TreasurerData data = listIterator.previous();
+
+            if (!map.containsKey(data.getProductId())) {
+                map.put(
+                    data.getProductId(),
+                    Septet.with(
+                        data.getEventTitle(),
+                        data.getOrganizedBy(),
+                        data.getProductTitle(),
+                        data.getPrice(),
+                        data.getAmount(),
+                        data.getVatRate(),
+                        data.getPrice()));
+            } else {
+                Double totalIncome = map.get(data.getProductId()).getValue3();
+                Integer totalAmount = map.get(data.getProductId()).getValue4();
+                map.put(
+                    data.getProductId(),
+                    Septet.with(
+                        data.getEventTitle(), 
+                        data.getOrganizedBy(),
+                        data.getProductTitle(),
+                        totalIncome + data.getPrice(),
+                        totalAmount + data.getAmount(),
+                        data.getVatRate(),
+                        data.getPrice()));
+            }
+        }
+        
+        // String csvContent = "Options:\n" + SalesexportSubmission.toString() + "\n\n";
+        // csvContent += "Event;Organized by;Product;Total income;Total amount;VAT rate\n";
+        String csvContent = "Event;Organized by;Product;Total income;Total amount;VAT rate;price\n";
+        for (Map.Entry<Integer, Septet<String, Integer, String, Double, Integer, String, Double>> entry : map.entrySet()) {
+            csvContent += entry.getValue().getValue0()                  // event title
+                        + ";" + LdapGroup.intToString(entry.getValue().getValue1()) // organized by
+                        + ";" + entry.getValue().getValue2()            // product title
+                        + ";" + entry.getValue().getValue3()            // total income
+                        + ";" + entry.getValue().getValue4()            // total amount
+                        + ";" + entry.getValue().getValue5()            // vat rate
+                        + ";" + entry.getValue().getValue6() + "\n";    // price
+        }
+
+        InputStream bufferedInputStream = new ByteArrayInputStream(csvContent.getBytes(StandardCharsets.UTF_8));
+        InputStreamResource fileInputStream = new InputStreamResource(bufferedInputStream);
+
+        String filename = "Sales_overview_"+SalesexportSubmission.getYear()+"-"+SalesexportSubmission.getMonth()+"_export.csv";
+
+        // setting HTTP headers
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + filename);
+        // defining the custom Content-Type
+        headers.set(HttpHeaders.CONTENT_TYPE, "text/csv");
+
+        return new ResponseEntity<>(
+                fileInputStream,
+                headers,
+                HttpStatus.OK
+        );
+    }
+}

--- a/src/main/java/ch/wisv/events/admin/controller/DashboardTreasurerController.java
+++ b/src/main/java/ch/wisv/events/admin/controller/DashboardTreasurerController.java
@@ -9,6 +9,8 @@ import java.util.*;
 import ch.wisv.events.core.repository.OrderRepository;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.apache.commons.lang3.tuple.Triple;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
@@ -57,20 +59,21 @@ public class DashboardTreasurerController extends DashboardController {
      * This method uses an intensive SQL query in the order repository. It filters order such that
      * all returned orders use IDEAL/SOFORT and were actually paid.
      *
-     * The treasurerRepository returns a list of TreasurerData that contains 4 parameters:
+     * The treasurerRepository returns a list of TreasurerData that contains 5 parameters:
      *  - the PaidAt date
      *  - The title of the product
      *  - The price of the product
      *  - The amount bought of the product
+     *  - The vatRate of the product
      *
      *  This is all the data required to create the treasurer data page.
      *
      * @return HashMap
      */
-    private Map<LocalDate, Map<String, Pair<Double, Integer>>> generateProductMap() {
+    private Map<LocalDate, Map<String, Triple<Double, Integer, String>>> generateProductMap() {
         List<TreasurerData> treasurerData = orderRepository.findallPayments();
         ListIterator<TreasurerData> listIterator = treasurerData.listIterator(treasurerData.size());
-        Map<LocalDate, Map<String, Pair<Double, Integer>>> map = new TreeMap<>();
+        Map<LocalDate, Map<String, Triple<Double, Integer, String>>> map = new TreeMap<>();
 
         while (listIterator.hasPrevious()) {
             TreasurerData data = listIterator.previous();
@@ -78,16 +81,18 @@ public class DashboardTreasurerController extends DashboardController {
             if (paidAt == null) {
                 continue;
             }
-
+            
+            // Set date to first of the month,
+            // in this way all orders that are paid in the same month will have the same date
             LocalDate date = paidAt.toLocalDate();
-            date = LocalDate.of(date.getYear(), date.getMonthValue(), 1);
+            date = LocalDate.of(date.getYear(), date.getMonthValue(), 1);            
 
-            Map<String, Pair<Double, Integer>> list = map.getOrDefault(date, new HashMap<>());
+            Map<String, Triple<Double, Integer, String>> list = map.getOrDefault(date, new HashMap<>());
             if (!list.containsKey(data.getTitle())) {
-                list.put(data.getTitle(), new ImmutablePair<>(data.getPrice(), data.getAmount()));
+                list.put(data.getTitle(), new ImmutableTriple<>(data.getPrice(), data.getAmount(), data.getVatRate()));
             } else {
                 list.put(data.getTitle(),
-                        new ImmutablePair<>(data.getPrice(), list.get(data.getTitle()).getRight()+data.getAmount())
+                        new ImmutableTriple<>(data.getPrice(), list.get(data.getTitle()).getMiddle()+data.getAmount(), data.getVatRate())
                 );
             }
 

--- a/src/main/java/ch/wisv/events/admin/controller/DashboardTreasurerController.java
+++ b/src/main/java/ch/wisv/events/admin/controller/DashboardTreasurerController.java
@@ -7,8 +7,6 @@ import java.time.LocalDateTime;
 import java.util.*;
 
 import ch.wisv.events.core.repository.OrderRepository;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Triple;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -88,11 +86,11 @@ public class DashboardTreasurerController extends DashboardController {
             date = LocalDate.of(date.getYear(), date.getMonthValue(), 1);            
 
             Map<String, Triple<Double, Integer, String>> list = map.getOrDefault(date, new HashMap<>());
-            if (!list.containsKey(data.getTitle())) {
-                list.put(data.getTitle(), new ImmutableTriple<>(data.getPrice(), data.getAmount(), data.getVatRate()));
+            if (!list.containsKey(data.getProductTitle())) {
+                list.put(data.getProductTitle(), new ImmutableTriple<>(data.getPrice(), data.getAmount(), data.getVatRate()));
             } else {
-                list.put(data.getTitle(),
-                        new ImmutableTriple<>(data.getPrice(), list.get(data.getTitle()).getMiddle()+data.getAmount(), data.getVatRate())
+                list.put(data.getProductTitle(),
+                        new ImmutableTriple<>(data.getPrice(), list.get(data.getProductTitle()).getMiddle()+data.getAmount(), data.getVatRate())
                 );
             }
 

--- a/src/main/java/ch/wisv/events/core/admin/SalesexportSubmission.java
+++ b/src/main/java/ch/wisv/events/core/admin/SalesexportSubmission.java
@@ -1,0 +1,70 @@
+package ch.wisv.events.core.admin;
+
+import ch.wisv.events.core.model.order.PaymentMethod;
+
+import lombok.Getter;
+import lombok.Setter;
+import java.util.*;
+import java.time.LocalDate;
+import java.time.LocalDate;
+import com.google.common.collect.Lists;
+
+
+/**
+ * Class that contains the settings for the salesexport query,
+ * which can be specified in on the form on the Sales Export tab.
+ */
+@Getter
+@Setter
+public class SalesexportSubmission {
+    
+    /**
+     * Year of query
+     */
+    private int year;
+
+    /**
+     * Month of query.
+     */
+    private int month;
+
+    /**
+     * Payment methods that should be contained in query.
+     */
+    private List<PaymentMethod> includedPaymentMethods;
+
+    private boolean freeProductsIncluded;
+
+    /**
+     * Default constructor.
+     */
+    public SalesexportSubmission() {
+        
+        // default: previous month
+        if (LocalDate.now().getMonthValue() == 1) {
+            this.year = LocalDate.now().getYear()-1;
+            this.month = 12;
+        }
+        else {
+            this.year = LocalDate.now().getYear();
+            this.month = LocalDate.now().getMonthValue()-1;
+        }
+        
+        this.includedPaymentMethods = Lists.newArrayList(PaymentMethod.IDEAL, PaymentMethod.SOFORT);
+
+        this.freeProductsIncluded = false;
+
+    }
+    
+    /**
+     * Return all options in a string.
+     */
+    public String toString() {
+        String settings = "Year: " + this.year + ", Month: " + this.month + ", Free products included: " + this.freeProductsIncluded;
+        for (PaymentMethod paymentMethod : this.includedPaymentMethods) {
+            settings += ", Payment method: " + paymentMethod.getName();
+        }
+        return settings;
+    }
+}   
+

--- a/src/main/java/ch/wisv/events/core/admin/TreasurerData.java
+++ b/src/main/java/ch/wisv/events/core/admin/TreasurerData.java
@@ -7,4 +7,5 @@ public interface TreasurerData {
     double getPrice();
     int getAmount();
     LocalDateTime getPaidAt();
+    String getVatRate();
 }

--- a/src/main/java/ch/wisv/events/core/admin/TreasurerData.java
+++ b/src/main/java/ch/wisv/events/core/admin/TreasurerData.java
@@ -3,9 +3,12 @@ package ch.wisv.events.core.admin;
 import java.time.LocalDateTime;
 
 public interface TreasurerData {
-    String getTitle();
+    int getProductId();
+    String getEventTitle();
+    int getOrganizedBy();
+    String getProductTitle();
     double getPrice();
     int getAmount();
-    LocalDateTime getPaidAt();
     String getVatRate();
+    LocalDateTime getPaidAt();
 }

--- a/src/main/java/ch/wisv/events/core/model/order/PaymentMethod.java
+++ b/src/main/java/ch/wisv/events/core/model/order/PaymentMethod.java
@@ -62,4 +62,12 @@ public enum PaymentMethod {
         return Math.round(e.evaluate() * 100.d) / 100.d;
     }
 
+    /**
+     * Return corresponding integer
+     *
+     * @return int
+     */
+    public int toInt() {
+        return this.ordinal();
+    }
 }

--- a/src/main/java/ch/wisv/events/core/repository/EventRepository.java
+++ b/src/main/java/ch/wisv/events/core/repository/EventRepository.java
@@ -10,7 +10,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import ch.wisv.events.core.admin.TreasurerData;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/ch/wisv/events/core/repository/OrderRepository.java
+++ b/src/main/java/ch/wisv/events/core/repository/OrderRepository.java
@@ -82,7 +82,7 @@ public interface OrderRepository extends JpaRepository<Order, Integer> {
     List<Order> findAllByOrderProducts(OrderProduct orderProduct);
 
     @Query(value =
-            "SELECT B.TITLE AS title,B.PRICE AS price,B.AMOUNT AS amount,O.PAID_AT AS paidAt " +
+            "SELECT B.TITLE AS title,B.PRICE AS price,B.AMOUNT AS amount,B.VAT_RATE AS vatRate, O.PAID_AT AS paidAt " +
                     "FROM " +
                     "( SELECT * " +
                     "FROM " +
@@ -91,6 +91,7 @@ public interface OrderRepository extends JpaRepository<Order, Integer> {
                     "P.TITLE," +
                     "OP.AMOUNT," +
                     "OP.PRICE," +
+                    "OP.VAT_RATE," +
                     "OP.ID AS OOPID " +
                     "FROM PRODUCT P " +
                     "INNER JOIN ORDER_PRODUCT OP ON P.ID = OP.PRODUCT_ID " +

--- a/src/main/java/ch/wisv/events/core/repository/OrderRepository.java
+++ b/src/main/java/ch/wisv/events/core/repository/OrderRepository.java
@@ -6,10 +6,13 @@ import ch.wisv.events.core.model.order.OrderProduct;
 import ch.wisv.events.core.model.order.OrderStatus;
 import java.util.List;
 import java.util.Optional;
+import java.util.Collection;
+import java.time.LocalDate;
 
 import ch.wisv.events.core.admin.TreasurerData;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * OrderRepository interface.
@@ -82,7 +85,7 @@ public interface OrderRepository extends JpaRepository<Order, Integer> {
     List<Order> findAllByOrderProducts(OrderProduct orderProduct);
 
     @Query(value =
-            "SELECT B.TITLE AS title,B.PRICE AS price,B.AMOUNT AS amount,B.VAT_RATE AS vatRate, O.PAID_AT AS paidAt " +
+            "SELECT B.TITLE AS productTitle,B.PRICE AS price,B.AMOUNT AS amount,B.VAT_RATE AS vatRate, O.PAID_AT AS paidAt " +
                     "FROM " +
                     "( SELECT * " +
                     "FROM " +
@@ -102,4 +105,54 @@ public interface OrderRepository extends JpaRepository<Order, Integer> {
                     "AND (O.PAYMENT_METHOD = 2 " +
                     "OR O.PAYMENT_METHOD = 3)", nativeQuery = true)
     List<TreasurerData> findallPayments();
+
+
+    /**
+     * Query for all orders with status PAID.
+     * 
+     * Also joins the product and event tables to get the information
+     * about the products (and corresponding event) that were bought in the order
+     * 
+     * @param month of type Integer. Filter query on month that the order was paid in (1-12)
+     * @param year of type Integer. Filter query on year that the order was paid in
+     * @param paymentMethods of type Collection<Integer>. Payment methods to include in the query
+     * @param includeFreeProducts of type boolean. Whether to include products with price 0 in the query
+     *
+     * @return List of TreasurerData. Contains the following fields:
+     * - productId
+     * - eventTitle
+     * - organizedBy
+     * - productTitle
+     * - price
+     * - amount
+     * - vatRate
+     * 
+     */
+    @Query(value ="""
+            SELECT
+                P.ID AS productId,
+                E.TITLE AS eventTitle,
+                E.ORGANIZED_BY AS organizedBy,
+                P.TITLE AS productTitle,
+                B.OP_PRICE AS price,
+                B.OP_AMOUNT AS amount,
+                P.VAT_RATE AS vatRate
+            FROM (
+                SELECT OP.PRICE AS OP_PRICE, OP.AMOUNT AS OP_AMOUNT, OP.PRODUCT_ID
+                FROM (
+                    SELECT OOP.ORDER_PRODUCTS_ID AS OPID
+                    FROM ORDERS O
+                    INNER JOIN ORDERS_ORDER_PRODUCTS OOP ON O.ID = OOP.ORDER_ID
+                    WHERE O.STATUS = 5
+                        AND EXTRACT(YEAR FROM O.PAID_AT) = :year
+                        AND EXTRACT(MONTH FROM O.PAID_AT) = :month
+                        AND O.PAYMENT_METHOD IN :paymentMethods
+                    ) A
+                INNER JOIN ORDER_PRODUCT OP ON A.OPID = OP.ID
+                WHERE (:includeFreeProducts OR OP.PRICE > 0)
+            ) B
+            INNER JOIN PRODUCT P ON B.PRODUCT_ID = P.ID
+            INNER JOIN EVENT_PRODUCTS EP ON P.ID = EP.PRODUCTS_ID
+            INNER JOIN EVENT E ON EP.EVENT_ID = E.ID""", nativeQuery = true)
+    List<TreasurerData> findallPaymentsByMonth(@Param("month") Integer month, @Param("year") Integer year, @Param("paymentMethods") Collection<Integer> paymentMethods, @Param("includeFreeProducts") boolean includeFreeProducts);
 }

--- a/src/main/java/ch/wisv/events/utils/LdapGroup.java
+++ b/src/main/java/ch/wisv/events/utils/LdapGroup.java
@@ -61,4 +61,15 @@ public enum LdapGroup {
         return name;
     }
 
+    /**
+     * Method intToString returns the name of the i-th LdapGroup.
+     *
+     * @param i of type int
+     * 
+     * @return String
+     */
+    public static String intToString(int i) {
+        return LdapGroup.values()[i].getName();
+    }
+
 }

--- a/src/main/resources/templates/admin/salesexport/index.html
+++ b/src/main/resources/templates/admin/salesexport/index.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <!-- Icons -->
+    <link rel="apple-touch-icon" sizes="180x180" th:href="@{/icons/apple-touch-icon.png}">
+    <link rel="icon" type="image/png" sizes="32x32" th:href="@{/icons/favicon-32x32.png}">
+    <link rel="icon" type="image/png" sizes="16x16" th:href="@{/icons/favicon-16x16.png}">
+    <link rel="manifest" th:href="@{/icons/site.webmanifest}">
+    <link rel="mask-icon" th:href="@{/icons/safari-pinned-tab.svg}" color="#1e274a">
+    <link rel="shortcut icon" th:href="@{/icons/favicon.ico}">
+    <meta name="msapplication-TileColor" content="#2b5797">
+    <meta name="msapplication-config" th:content="@{/icons/browserconfig.xml}">
+    <meta name="theme-color" content="#ffffff">
+
+    <title>CH Events - Dashboard > Example</title>
+
+    <!--Bootstrap core CSS -->
+    <link th:href="@{/webjars/wisvch-bootstrap-theme/dist/css/bootstrap.min.css}" rel="stylesheet">
+    <link rel="stylesheet" href="https://use.typekit.net/uet5duo.css" integrity="sha384-Bg9blBrAm2v7bP2AhXtjHdM8p8EeT4YJLHwfJ/1O257DAiLyqhVtYdCB3dzdZsmb" crossorigin="anonymous">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+    <link th:href="@{/css/dashboard.css}" rel="stylesheet">
+    <link th:href="@{/css/wisvch-dashboard.css}" rel="stylesheet">
+
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.10.16/css/dataTables.bootstrap4.min.css" integrity="sha384-bsGkvB1NLsaPUZL6GG0N5H9GOW9DK6KiHrrDvO57EJXoD9H3gzlohtuPENw9/24L" crossorigin="anonymous">
+    <link rel="stylesheet" th:href="@{/webjars/font-awesome/5.0.13/web-fonts-with-css/css/fontawesome-all.min.css}">
+</head>
+
+<body>
+<nav th:replace="fragments/header :: header"></nav>
+
+<div class="container-fluid">
+    <div class="row">
+        <nav th:replace="admin/sidebar :: sidebar"></nav>
+        
+        <main class="col-sm-9 ml-sm-auto col-md-10 p-5" role="main">
+            <h1>Export Sales
+                <a class="badge badge-danger" th:href="@{/administrator/treasurer}">
+                    Old Treasurer Tab
+                </a>
+            </h1>
+            <div th:replace="fragments/messages :: messages"></div>
+            <form th:action="@{./csv}" th:object="${SalesexportSubmission}" method="GET">
+                <div class="col">
+                    <div class="row">
+                        <div class="col">
+                            <div class="card mb-4">
+                                <h6 class="card-header">Month</h6>
+                                <div class="card-body">
+                                    <div class="row form">
+                                        <div class="form-group col-12">
+                                            <div class="row">
+                                                <div class="form-group col-6">
+                                                    <label>Year: <input type="number" class="form-control" th:field="*{year}" /></label>
+                                                </div>
+                                                <div class="form-group col-6">
+                                                    <label>Month: <input type="number" class="form-control" th:field="*{month}" /></label>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col">
+                            <div class="card mb-4">
+                                <h6 class="card-header">Advanced Settings</h6>
+                                <div class="card-body">
+                                    <div class="col form">
+                                        <h7>Include payment methods:</h7>
+                                        <div class="custom-control custom-checkbox" th:each="payMethod : ${T(ch.wisv.events.core.model.order.PaymentMethod).values()}">
+                                            <input type="checkbox" class="custom-control-input"
+                                            th:id="'includeCheck' + ${payMethod}"
+                                            th:field="*{includedPaymentMethods}"
+                                            th:value="${payMethod}"
+                                            th:checked="${SalesexportSubmission.getIncludedPaymentMethods().contains(payMethod)}">
+                                            <label class="custom-control-label text-dark font-weight-normal" th:for="'includeCheck' + ${payMethod}">[[${payMethod.getName()}]]</label>
+                                        </div>
+                                        <h7>Include free products:</h7>
+                                        <!-- <label>Include free products <input type="checkbox" class="custom-control-input" th:field="*{freeProductsIncluded}" /></label> -->
+                                        <div class="custom-control custom-checkbox">
+                                            <input type="checkbox" class="custom-control-input"
+                                            id="includeFreeProducts"
+                                            th:field="*{freeProductsIncluded}"
+                                            th:checked="${SalesexportSubmission.isFreeProductsIncluded()}"
+                                            />
+                                            <label class="custom-control-label text-dark font-weight-normal"
+                                            for="includeFreeProducts">Include free products (also select all payment methods)</label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="card mb-4">
+                        <div class="card-body">
+                            <input type="submit" class="btn btn-secondary" value="Export" />
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </main>
+    </div>
+</div>
+</body>

--- a/src/main/resources/templates/admin/sidebar.html
+++ b/src/main/resources/templates/admin/sidebar.html
@@ -54,9 +54,9 @@
     </ul>
     <ul class="nav nav-pills flex-column">
         <li class="nav-item">
-            <a th:href="@{/administrator/treasurer/}" class="nav-link"
-               th:classappend="${#httpServletRequest.getRequestURI().contains('/administrator/treasurer/') ? 'active':''}">
-                <i class="far fa-money-bill-alt fa-fw" aria-hidden="true"></i> Treasurer
+            <a th:href="@{/administrator/salesexport/}" class="nav-link"
+               th:classappend="${#httpServletRequest.getRequestURI().contains('/administrator/salesexport/') ? 'active':''}">
+                <i class="far fa-money-bill-alt fa-fw" aria-hidden="true"></i> Sales Export
             </a>
         </li>
     </ul>

--- a/src/main/resources/templates/admin/treasurer/index.html
+++ b/src/main/resources/templates/admin/treasurer/index.html
@@ -60,18 +60,21 @@
                                 <tr>
                                     <th>Name</th>
                                     <th class="text-center">Number</th>
-                                    <th class="text-center">Price</th>
+                                    <th class="text-right">Price</th>
                                     <th class="text-right">Total</th>
+                                    <th class="text-center">VAT</th>
                                 </tr>
                                 </thead>
                                 <tbody>
                                 <tr th:each="product : ${date.value}">
                                     <td th:text="${product.key}"></td>
-                                    <td th:text="${product.value.getRight()}" class="text-center"></td>
+                                    <td th:text="${product.value.getMiddle()}" class="text-center"></td>
                                     <td th:text="'€ ' + ${#numbers.formatDecimal(product.value.getLeft(), 1, 'POINT', 2, 'COMMA')}"
                                         class="text-right">
-                                    <td th:text="'€ ' + ${#numbers.formatDecimal(product.value.getLeft() * product.value.getRight(), 1, 'POINT', 2, 'COMMA')}"
+                                    <td th:text="'€ ' + ${#numbers.formatDecimal(product.value.getLeft() * product.value.getMiddle(), 1, 'POINT', 2, 'COMMA')}"
                                         class="text-right"></td>
+                                    <td th:text="${product.value.getRight()}"
+                                        class="text-center"></td>
                                 </tr>
                                 </tbody>
                                 <tfoot>
@@ -80,6 +83,7 @@
                                     <th class="sum text-center"></th>
                                     <th class="sum currency text-right"></th>
                                     <th class="sum currency text-right"></th>
+                                    <th></th>
                                 </tr>
                                 </tfoot>
                             </table>

--- a/src/main/resources/templates/admin/treasurer/index.html
+++ b/src/main/resources/templates/admin/treasurer/index.html
@@ -60,8 +60,8 @@
                                 <tr>
                                     <th>Name</th>
                                     <th class="text-center">Number</th>
-                                    <th class="text-right">Price</th>
-                                    <th class="text-right">Total</th>
+                                    <th class="text-center">Price</th>
+                                    <th class="text-center">Total</th>
                                     <th class="text-center">VAT</th>
                                 </tr>
                                 </thead>
@@ -133,7 +133,7 @@
                 paging: false,
                 "bInfo": false,
                 columnDefs: [
-                    {width: "100px", targets: [1, 2, 3]}
+                    {width: "100px", targets: [1, 2, 3, 4]}
                 ]
             });
 

--- a/src/test/java/ch/wisv/events/admin/controller/DashboardSalesexportControllerTest.java
+++ b/src/test/java/ch/wisv/events/admin/controller/DashboardSalesexportControllerTest.java
@@ -1,0 +1,54 @@
+package ch.wisv.events.admin.controller;
+
+import ch.wisv.events.ControllerTest;
+import ch.wisv.events.EventsApplicationTest;
+import ch.wisv.events.core.model.event.Event;
+import ch.wisv.events.core.model.customer.Customer;
+import ch.wisv.events.core.model.order.Order;
+import ch.wisv.events.core.model.order.OrderStatus;
+import ch.wisv.events.core.model.product.Product;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.TreeMap;
+import org.json.simple.JSONObject;
+
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.apache.commons.lang3.tuple.Triple;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = EventsApplicationTest.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+public class DashboardSalesexportControllerTest extends ControllerTest {
+
+    @Test
+    public void testCsvExport() throws Exception {
+        Product product = this.createProduct();
+        Event event = this.createEvent();
+        event.addProduct(product);
+        Customer customer = this.createCustomer();
+        Order order = this.createOrder(customer, ImmutableList.of(product), OrderStatus.PENDING, "test");
+        orderService.updateOrderStatus(order, OrderStatus.PAID);
+
+        Order order1 = this.createOrder(customer, ImmutableList.of(product), OrderStatus.PENDING, "test");
+        orderService.updateOrderStatus(order1, OrderStatus.PAID);
+
+        mockMvc.perform(get("/administrator/salesexport/csv"))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(content().contentType("text/csv"));
+    }
+}

--- a/src/test/java/ch/wisv/events/admin/controller/DashboardTreasurerControllerTest.java
+++ b/src/test/java/ch/wisv/events/admin/controller/DashboardTreasurerControllerTest.java
@@ -15,6 +15,8 @@ import java.util.TreeMap;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.apache.commons.lang3.tuple.Triple;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -40,10 +42,10 @@ public class DashboardTreasurerControllerTest extends ControllerTest {
         Order order1 = this.createOrder(customer, ImmutableList.of(product), OrderStatus.PENDING, "test");
         orderService.updateOrderStatus(order1, OrderStatus.PAID);
 
-        Map<LocalDate, Map<String, Pair<Double, Integer>>> map = new TreeMap<>();
+        Map<LocalDate, Map<String, Triple<Double, Integer, String>>> map = new TreeMap<>();
         LocalDate date = order.getPaidAt().toLocalDate();
         map.put(LocalDate.of(date.getYear(), date.getMonthValue(), 1), ImmutableMap.of(product.title,
-                new ImmutablePair<>(product.cost, 2)));
+                new ImmutableTriple<>(product.cost, 2, product.vatRate.name())));
 
         mockMvc.perform(get("/administrator/treasurer"))
                 .andExpect(status().is2xxSuccessful())


### PR DESCRIPTION
This admin tab can be used by the treasurer to export all orders of a certain month to csv. The treasurer can then use this csv to import to the bookkeeping. This is more efficient for the treasurer. Some remarks:
- The old treasurer tab is still available through a button on the sales export tab
- There are a few extra options on the sales export tab that were not available on the old treasurer tab, however the default options are the same as the options on the old tab
- I have added a new class SalesAdminSubmission that is used to store the values on the html form on the sales export tab. It is placed under src/main/java/ch/wisv/events/core/admin/SalesexportSubmission.java, however, I wasn't certain if this is the right place to store it, let me know if there are better ways to do this.
- I have added a test for the sales export page, however it only checks whether a csv is exported and not whether the contents are correct. I also tried to write a test for this, but couldn't get it to work.