### PR TITLE
Add attendance to committee sales page

### DIFF
--- a/src/main/java/ch/wisv/events/sales/controller/stats/SalesStatsController.java
+++ b/src/main/java/ch/wisv/events/sales/controller/stats/SalesStatsController.java
@@ -122,6 +122,7 @@ public class SalesStatsController {
         model.addAttribute("ticketsSold", ticketsSold);
         model.addAttribute("event", event);
         model.addAttribute("key", event.getKey());
+        model.addAttribute("attendance", eventService.getAttendance(event));
 
         return "sales/stats/event/index";
     }

--- a/src/main/resources/templates/sales/stats/event/index.html
+++ b/src/main/resources/templates/sales/stats/event/index.html
@@ -41,7 +41,7 @@
         <main class="col-sm-9 ml-sm-auto col-md-10 p-5" role="main">
             <h1 th:text="${event.getTitle()}"/>
             <div class="row">
-                <div class="col">
+                <div class="col-md">
                     <div class="card mb-3">
                         <h6 class="card-header">Total number of tickets sold:</h6>
                         <div class="card-body text-primary">
@@ -60,13 +60,31 @@
                         </div>
                     </div>
                 </div>
-                <div class="col">
+                <div class="col-sm">
                     <div class="card mb-3">
                         <h6 class="card-header">Amount of money earned:</h6>
                         <div class="card-body text-primary">
                             <h4 class="card-title">
                                 € [[${moneyEarned}]]
                             </h4>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md">
+                    <div class="card mb-3">
+                        <h6 class="card-header">Number of tickets scanned:</h6>
+                        <div class="card-body text-primary">
+                            <h4 class="card-title">
+                                [[${attendance.getScannedCount()}]] <small>out of [[${attendance.getTicketsCount()}]]</small>
+                            </h4>
+                            <div class="progress mb-2">
+                                <div class="progress-bar" role="progressbar"
+                                     th:aria-valuenow="${attendance.getPercentageScanned()}"
+                                     aria-valuemin="0" aria-valuemax="100"
+                                     th:style="'width: ' + ${attendance.getPercentageScanned()} + '%;'"
+                                     th:text="${attendance.getPercentageScanned()} + '%'">
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This PR adds the attendance (number of scanned tickets) to the committee sales page.
This way the committee members can see it, and its also easier to access to the board while scanning tickets.

<img width="412" alt="Scherm­afbeelding 2024-01-06 om 10 25 53" src="https://github.com/WISVCH/events/assets/13507227/b2dce606-62ad-4229-8847-74f83d3a540b">
<img width="2555" alt="Scherm­afbeelding 2024-01-06 om 10 25 38" src="https://github.com/WISVCH/events/assets/13507227/53c3a759-7396-49d3-ac85-67df2dd21b8a">
