### PR TITLE
The /checkout endpoint should ignore CSRF

### DIFF
--- a/src/main/java/ch/wisv/events/ChConnectConfiguration.java
+++ b/src/main/java/ch/wisv/events/ChConnectConfiguration.java
@@ -80,7 +80,7 @@ public class ChConnectConfiguration {
                     )
                 .csrf(csrf -> csrf
                     .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-                    .ignoringRequestMatchers("/api/v1/**")
+                    .ignoringRequestMatchers("/api/v1/**", "/checkout")
                 )
                 .oauth2Login(oauth -> oauth
                     .userInfoEndpoint(userInfo -> userInfo 


### PR DESCRIPTION
I believe this endpoint should not be under CSRF protection. If it is, then first time users or people who have not used the application in a while will get an error page when trying to checkout the first time, which is not intended.

The issue and reasoning for adding this to the ignore filter has been discussed in issue #492 .

fixes #492 