### PR TITLE
Add Locale to String.format in CSV generation

### DIFF
--- a/src/main/java/ch/wisv/events/admin/controller/DashboardSalesExportController.java
+++ b/src/main/java/ch/wisv/events/admin/controller/DashboardSalesExportController.java
@@ -159,10 +159,10 @@ public class DashboardSalesExportController extends DashboardController {
             csvContent.append(entry.getValue().eventTitle)
                     .append(";").append(entry.getValue().organizedBy)           // organized by
                     .append(";").append(entry.getValue().productTitle)          // product title
-                    .append(";").append(String.format("%.2f", entry.getValue().totalIncome)) // total income
+                    .append(";").append(String.format(Locale.US, "%.2f", entry.getValue().totalIncome)) // total income
                     .append(";").append(entry.getValue().totalAmount)           // total amount
                     .append(";").append(entry.getValue().vatRate)               // vat rate
-                    .append(";").append(String.format("%.2f", entry.getValue().price)).append("\n"); // price
+                    .append(";").append(String.format(Locale.US, "%.2f", entry.getValue().price)).append("\n"); // price
         }
     return csvContent.toString();
     }


### PR DESCRIPTION
Add Locale to String.format such that it always uses a decimal point and not a comma

This ensures all tests also run locally.