### PR TITLE
Wallet: Remove the requirement to be authenticated, add fallback when no location is set

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,37 +1,37 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/java-postgres
 {
-	"name": "Java & PostgreSQL",
-	"dockerComposeFile": "docker-compose.yml",
-	"service": "app",
-	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	"features": {
-		"ghcr.io/devcontainers/features/java:1": {
-			"installGradle": "true"
-		}
-	},
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// This can be used to network with other containers or with the host.
-	"forwardPorts": [
-		1080, // Mailcatcher
-		5432, // PostgreSQL
-		8080, // Events
-		8082  // Adminer
-	],
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "gradle bootRun",
-	// Configure tool-specific properties.
-	// "customizations": {},
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	"remoteUser": "root",
-	"customizations": {
-		"vscode": {
-			"extensions": [
-				"vmware.vscode-boot-dev-pack",
-				"vscjava.vscode-gradle",
-				"vscjava.vscode-java-pack"
-			]
-		}
-	}
+  "name": "Java & PostgreSQL",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    "ghcr.io/devcontainers/features/java:1.6.0": {
+      "installGradle": "true"
+    }
+  },
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // This can be used to network with other containers or with the host.
+  "forwardPorts": [
+    1080, // Mailcatcher
+    5432, // PostgreSQL
+    8080, // Events
+    8082 // Adminer
+  ],
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "gradle bootRun",
+  // Configure tool-specific properties.
+  // "customizations": {},
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  "remoteUser": "root",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "vmware.vscode-boot-dev-pack",
+        "vscjava.vscode-gradle",
+        "vscjava.vscode-java-pack"
+      ]
+    }
+  }
 }

--- a/src/main/java/ch/wisv/events/core/service/googlewallet/GoogleWalletServiceImpl.java
+++ b/src/main/java/ch/wisv/events/core/service/googlewallet/GoogleWalletServiceImpl.java
@@ -149,6 +149,7 @@ public class GoogleWalletServiceImpl implements GoogleWalletService {
                 .setHexBackgroundColor("#1e274a")
                 .setFaceValue(cost)
                 .setBarcode(new Barcode().setType("QR_CODE").setValue(ticket.getUniqueCode()))
+                .setGroupingInfo(new GroupingInfo().setGroupingId(ticket.product.event.getKey()).setSortIndex(1))
                 .setLinksModuleData(new LinksModuleData().setUris(Arrays.asList(tnc)));
     }
 

--- a/src/main/java/ch/wisv/events/core/service/googlewallet/GoogleWalletServiceImpl.java
+++ b/src/main/java/ch/wisv/events/core/service/googlewallet/GoogleWalletServiceImpl.java
@@ -107,6 +107,12 @@ public class GoogleWalletServiceImpl implements GoogleWalletService {
                 .setDescription("Terms & Conditions")
                 .setId("LINK_GTC");
 
+        String locationName = product.getEvent().getLocation();
+
+        if(locationName == null || locationName.trim().isEmpty()) {
+            locationName = "Unknown";
+        }
+
         return new EventTicketClass()
                 .setId(this.getClassId(product))
                 .setIssuerName("Christiaan Huygens")
@@ -120,7 +126,7 @@ public class GoogleWalletServiceImpl implements GoogleWalletService {
                         .setUri(homePage)
                         .setDescription("Events"))
                 .setVenue(new EventVenue()
-                        .setName(this.makeLocalString(product.getEvent().getLocation()))
+                        .setName(this.makeLocalString(locationName))
                         .setAddress(this.makeLocalString("Mekelweg 4, 2628 CD Delft")))
                 .setDateTime(new EventDateTime()
                         .setStart(this.formatDate(product.getEvent().getStart()))

--- a/src/main/java/ch/wisv/events/core/service/ticket/TicketServiceImpl.java
+++ b/src/main/java/ch/wisv/events/core/service/ticket/TicketServiceImpl.java
@@ -285,9 +285,8 @@ public class TicketServiceImpl implements TicketService {
     public byte[] getApplePass(Ticket ticket) throws TicketPassFailedException {
         try {
             RestTemplate restTemplate = new RestTemplate();
-
-
             Map<String, String> params = new HashMap<>();
+
             params.put("title", ticket.getProduct().getTitle());
             params.put("description", ticket.getProduct().getDescription());
             params.put("date", ticket.getProduct().getEvent().getStart().format(DateTimeFormatter.ISO_LOCAL_DATE));

--- a/src/main/java/ch/wisv/events/webshop/controller/WebshopPassesController.java
+++ b/src/main/java/ch/wisv/events/webshop/controller/WebshopPassesController.java
@@ -37,17 +37,9 @@ public class WebshopPassesController extends WebshopController {
      * Get wallet pass of ticket.
      */
     @GetMapping("/apple/{key}/wallet.pkpass")
-    public void getApplePass(HttpServletResponse response, @PathVariable  String key) throws IOException {
-        Customer customer = authenticationService.getCurrentCustomer();
-
+    public void getApplePass(HttpServletResponse response, @PathVariable String key) throws IOException {
         try {
             Ticket ticket = ticketService.getByKey(key);
-
-            if (!ticket.owner.equals(customer) && ticket.owner.isVerifiedChMember()) {
-                response.sendError(HttpServletResponse.SC_FORBIDDEN);
-                return;
-            }
-
             byte[] bytes = ticketService.getApplePass(ticket);
 
             response.setContentType("application/vnd.apple.pkpass");
@@ -68,17 +60,10 @@ public class WebshopPassesController extends WebshopController {
      */
     @GetMapping("/google/{key}")
     public void getGooglePass(HttpServletResponse response, @PathVariable String key) throws IOException {
-        Customer customer = authenticationService.getCurrentCustomer();
-
         try {
             Ticket ticket = ticketService.getByKey(key);
-
-            if (!ticket.owner.equals(customer) && ticket.owner.isVerifiedChMember()) {
-                response.sendError(HttpServletResponse.SC_FORBIDDEN);
-                return;
-            }
-
             String link = ticketService.getGooglePass(ticket);
+
             response.sendRedirect(link);
         }
         catch (TicketNotFoundException e) {


### PR DESCRIPTION
People are running into a generic error when trying to add a ticket to their {Apple, Google} Wallet. Since the ticket key is sufficiently random, we can just remove the requirement to be authenticated.

Secondly for the Google Wallet we get an error when no location is set for a ticket. This also adds a fallback location (Unknown), so it still proceeds.