### PR TITLE
Use new chpay api

### DIFF
--- a/config/application-devcontainer.yml
+++ b/config/application-devcontainer.yml
@@ -93,7 +93,7 @@ wisvch.events:
 
 # CH Pay Configuration
 wisvch.chpay:
-  uri: http://localhost:8080/api/events
+  uri: http://localhost:8080/api/v1
   api-key: test
   clientUri:  http://localhost:8080/events/
 

--- a/config/application-test.yml
+++ b/config/application-test.yml
@@ -69,7 +69,7 @@ wisvch.events:
 
 # CH Pay Configuration
 wisvch.chpay:
-  uri: http://localhost:8080/api/events
+  uri: http://localhost:8080/api/v1
   api-key: <api-key>
   clientUri:  http://localhost:8080/events/
 

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -81,7 +81,7 @@ wisvch.events:
 
 # CH Pay Configuration
 wisvch.chpay:
-  uri: http://localhost:8080/api/events
+  uri: http://localhost:8080/api/v1
   api-key: <api-key>
   clientUri:  http://localhost:8080/events/
 

--- a/src/main/java/ch/wisv/events/webshop/service/PaymentsServiceImpl.java
+++ b/src/main/java/ch/wisv/events/webshop/service/PaymentsServiceImpl.java
@@ -135,11 +135,11 @@ public class PaymentsServiceImpl implements PaymentsService {
         request.setMetadata(metadata);
 
         HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.set("X-API-KEY", chpayApiKey);
+        httpHeaders.setBearerAuth(chpayApiKey);
         httpHeaders.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<CHPaymentRequest> requestEntity = new HttpEntity<>(request, httpHeaders);
 
-        ResponseEntity<CHPaymentResponse> response = restTemplate.postForEntity(chPayApi, requestEntity, CHPaymentResponse.class);
+        ResponseEntity<CHPaymentResponse> response = restTemplate.postForEntity(chPayApi + "/external-payment", requestEntity, CHPaymentResponse.class);
 
         if(response.getStatusCode().is2xxSuccessful()){
             CHPaymentResponse body = response.getBody();
@@ -312,12 +312,12 @@ public class PaymentsServiceImpl implements PaymentsService {
         try {
             UUID paymentID = UUID.fromString(order.getChPaymentsReference());
 
-            UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(CHPayUri + "/status").queryParam("PaymentId", paymentID);
+            UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(CHPayUri + "/external-payment/status").queryParam("PaymentId", paymentID);
 
             RestTemplate restTemplate = new RestTemplate();
 
             HttpHeaders httpHeaders = new HttpHeaders();
-            httpHeaders.set("X-API-KEY", chpayApiKey);
+            httpHeaders.setBearerAuth(chpayApiKey);
             httpHeaders.setContentType(MediaType.APPLICATION_JSON);
             HttpEntity<Void> entity = new HttpEntity<>(httpHeaders);
 


### PR DESCRIPTION
The new api uses a standard auth header instead of a custom one, and a new api path.