### PR TITLE
Fix sales

### DIFF
--- a/src/main/java/ch/wisv/events/core/repository/EventRepository.java
+++ b/src/main/java/ch/wisv/events/core/repository/EventRepository.java
@@ -4,8 +4,10 @@ import ch.wisv.events.core.admin.Attendance;
 import ch.wisv.events.core.model.event.Event;
 import ch.wisv.events.core.model.event.EventStatus;
 import ch.wisv.events.core.model.product.Product;
+import ch.wisv.events.utils.LdapGroup;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -35,6 +37,36 @@ public interface EventRepository extends JpaRepository<Event, Integer> {
      * @return List
      */
     List<Event> findAllByPublishedAndEndingIsAfter(EventStatus published, LocalDateTime ending);
+
+    /**
+     * Find all sales-visible events (upcoming from start of day and published/not published).
+     *
+     * @param dateTime of type LocalDateTime
+     * @param statuses of type EventStatus collection
+     *
+     * @return list of events
+     */
+    @Query("select e from Event e where e.ending >= :dateTime and e.published in :statuses order by e.start asc")
+    List<Event> findAllSalesVisibleEvents(
+            @Param("dateTime") LocalDateTime dateTime,
+            @Param("statuses") Collection<EventStatus> statuses
+    );
+
+    /**
+     * Find all sales-visible events for specific organizing LDAP groups.
+     *
+     * @param dateTime of type LocalDateTime
+     * @param statuses of type EventStatus collection
+     * @param groups   of type LdapGroup collection
+     *
+     * @return list of events
+     */
+    @Query("select e from Event e where e.ending >= :dateTime and e.published in :statuses and e.organizedBy in :groups order by e.start asc")
+    List<Event> findAllSalesVisibleEventsByOrganizedByIn(
+            @Param("dateTime") LocalDateTime dateTime,
+            @Param("statuses") Collection<EventStatus> statuses,
+            @Param("groups") Collection<LdapGroup> groups
+    );
 
     /**
      * Find an Event by key.

--- a/src/main/java/ch/wisv/events/sales/controller/scan/SalesScanEventController.java
+++ b/src/main/java/ch/wisv/events/sales/controller/scan/SalesScanEventController.java
@@ -1,8 +1,11 @@
 package ch.wisv.events.sales.controller.scan;
 
 import ch.wisv.events.core.exception.normal.EventNotFoundException;
+import ch.wisv.events.core.model.customer.Customer;
 import ch.wisv.events.core.model.event.Event;
+import ch.wisv.events.core.service.auth.AuthenticationService;
 import ch.wisv.events.core.service.event.EventService;
+import ch.wisv.events.sales.service.SalesService;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -30,14 +33,26 @@ public class SalesScanEventController {
 
     /** EventService. */
     private final EventService eventService;
+    /** AuthenticationService. */
+    private final AuthenticationService authenticationService;
+    /** SalesService. */
+    private final SalesService salesService;
 
     /**
      * SalesScanEventController.
      *
-     * @param eventService of type EventService
+     * @param eventService          of type EventService
+     * @param authenticationService of type AuthenticationService
+     * @param salesService          of type SalesService
      */
-    public SalesScanEventController(EventService eventService) {
+    public SalesScanEventController(
+            EventService eventService,
+            AuthenticationService authenticationService,
+            SalesService salesService
+    ) {
         this.eventService = eventService;
+        this.authenticationService = authenticationService;
+        this.salesService = salesService;
     }
 
     /**
@@ -54,6 +69,12 @@ public class SalesScanEventController {
     public String scanner(Model model, RedirectAttributes redirect, @PathVariable String key, @PathVariable String method) {
         try {
             Event event = eventService.getByKey(key);
+            Customer currentUser = authenticationService.getCurrentCustomer();
+            if (!salesService.hasAccessToEvent(currentUser, event)) {
+                redirect.addFlashAttribute(ATTR_ERROR, "You do not have access to this event.");
+
+                return ERROR_REDIRECT;
+            }
             model.addAttribute(ATTR_EVENT, event);
 
             return "sales/scan/event/" + method;

--- a/src/main/java/ch/wisv/events/sales/controller/scan/SalesScanRestController.java
+++ b/src/main/java/ch/wisv/events/sales/controller/scan/SalesScanRestController.java
@@ -2,15 +2,18 @@ package ch.wisv.events.sales.controller.scan;
 
 import ch.wisv.events.core.exception.normal.EventsException;
 import ch.wisv.events.core.exception.normal.TicketNotFoundException;
+import ch.wisv.events.core.model.customer.Customer;
 import ch.wisv.events.core.model.event.Event;
 import ch.wisv.events.core.model.ticket.Ticket;
 import ch.wisv.events.core.model.ticket.TicketStatus;
+import ch.wisv.events.core.service.auth.AuthenticationService;
 import ch.wisv.events.core.service.event.EventService;
 import ch.wisv.events.core.service.ticket.TicketService;
 import static ch.wisv.events.utils.ResponseEntityBuilder.createResponseEntity;
 import java.util.Objects;
 
 import ch.wisv.events.sales.model.ScanDto;
+import ch.wisv.events.sales.service.SalesService;
 import org.json.simple.JSONObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -41,16 +44,29 @@ public class SalesScanRestController {
 
     /** TicketService. */
     private final TicketService ticketService;
+    /** AuthenticationService. */
+    private final AuthenticationService authenticationService;
+    /** SalesService. */
+    private final SalesService salesService;
 
     /**
      * SalesScanRestController.
      *
-     * @param eventService  of type EventService
-     * @param ticketService of type TicketService
+     * @param eventService          of type EventService
+     * @param ticketService         of type TicketService
+     * @param authenticationService of type AuthenticationService
+     * @param salesService          of type SalesService
      */
-    public SalesScanRestController(EventService eventService, TicketService ticketService) {
+    public SalesScanRestController(
+            EventService eventService,
+            TicketService ticketService,
+            AuthenticationService authenticationService,
+            SalesService salesService
+    ) {
         this.eventService = eventService;
         this.ticketService = ticketService;
+        this.authenticationService = authenticationService;
+        this.salesService = salesService;
     }
 
     /**
@@ -122,6 +138,10 @@ public class SalesScanRestController {
 
         try {
             Event event = eventService.getByKey(key);
+            Customer currentUser = authenticationService.getCurrentCustomer();
+            if (!salesService.hasAccessToEvent(currentUser, event)) {
+                return createResponseEntity(HttpStatus.FORBIDDEN, "You do not have access to this event.");
+            }
             Ticket ticket = this.getTicketByUniqueCode(event, code);
             ScanDto scan = new ScanDto(ticket.getProduct().getTitle(), ticket.getOwner().getName());
 

--- a/src/main/java/ch/wisv/events/sales/controller/sell/SalesSellCustomerController.java
+++ b/src/main/java/ch/wisv/events/sales/controller/sell/SalesSellCustomerController.java
@@ -97,6 +97,7 @@ public class SalesSellCustomerController {
 
             return "redirect:/sales/sell/order/" + order.getPublicReference();
         } catch (CustomerNotFoundException e) {
+            redirect.addFlashAttribute("customer", customer);
             return "redirect:/sales/sell/customer/" + order.getPublicReference() + "/create";
         } catch (EventsException e) {
             redirect.addFlashAttribute("error", e.getMessage());
@@ -139,7 +140,7 @@ public class SalesSellCustomerController {
 
             redirect.addFlashAttribute("success", "Customer successfully created!");
 
-            return "redirect:/sales/order/" + order.getPublicReference();
+            return "redirect:/sales/sell/order/" + order.getPublicReference();
         } catch (CustomerInvalidException e) {
             redirect.addFlashAttribute("error", e.getMessage());
             redirect.addFlashAttribute("customer", customer);

--- a/src/main/java/ch/wisv/events/sales/controller/sell/SalesSellCustomerController.java
+++ b/src/main/java/ch/wisv/events/sales/controller/sell/SalesSellCustomerController.java
@@ -24,7 +24,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
  * SalesSellCustomerController class.
  */
 @Controller
-@PreAuthorize("hasRole('USER')")
+@PreAuthorize("hasRole('ADMIN')")
 @RequestMapping("/sales/sell/customer/{publicReference}")
 public class SalesSellCustomerController {
 

--- a/src/main/java/ch/wisv/events/sales/controller/sell/SalesSellMainController.java
+++ b/src/main/java/ch/wisv/events/sales/controller/sell/SalesSellMainController.java
@@ -23,7 +23,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
  */
 @Controller
 @RequestMapping(value = "/sales/sell")
-@PreAuthorize("hasRole('USER')")
+@PreAuthorize("hasRole('ADMIN')")
 public class SalesSellMainController {
 
     /** AuthenticationService. */

--- a/src/main/java/ch/wisv/events/sales/controller/sell/SalesSellOrderController.java
+++ b/src/main/java/ch/wisv/events/sales/controller/sell/SalesSellOrderController.java
@@ -15,7 +15,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
  * SalesSellOrderController class.
  */
 @Controller
-@PreAuthorize("hasRole('USER')")
+@PreAuthorize("hasRole('ADMIN')")
 @RequestMapping(value = "/sales/sell/order/{publicReference}")
 public class SalesSellOrderController {
 

--- a/src/main/java/ch/wisv/events/sales/controller/sell/SalesSellPaymentController.java
+++ b/src/main/java/ch/wisv/events/sales/controller/sell/SalesSellPaymentController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
-@PreAuthorize("hasRole('USER')")
+@PreAuthorize("hasRole('ADMIN')")
 @RequestMapping(value = "/sales/sell/payment/{publicReference}")
 public class SalesSellPaymentController {
 

--- a/src/main/java/ch/wisv/events/sales/controller/stats/SalesStatsController.java
+++ b/src/main/java/ch/wisv/events/sales/controller/stats/SalesStatsController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -83,8 +84,14 @@ public class SalesStatsController {
      * @return String
      */
     @GetMapping("/products/{key}")
-    public String ticketSalesindex(Model model, @PathVariable String key) throws EventNotFoundException {
+    public String ticketSalesindex(Model model, RedirectAttributes redirect, @PathVariable String key) throws EventNotFoundException {
         Event event = eventService.getByKey(key);
+        Customer currentUser = authenticationService.getCurrentCustomer();
+        if (!salesService.hasAccessToEvent(currentUser, event)) {
+            redirect.addFlashAttribute("error", "You do not have access to this event.");
+
+            return ERROR_REDIRECT;
+        }
 
         model.addAttribute("products", event.getProducts());
         model.addAttribute("target", event.getTarget());
@@ -101,8 +108,15 @@ public class SalesStatsController {
      * @return String
      */
     @GetMapping("/event/{key}")
-    public String eventSalesView(Model model, @PathVariable String key) throws EventNotFoundException {
+    public String eventSalesView(Model model, RedirectAttributes redirect, @PathVariable String key) throws EventNotFoundException {
         Event event = eventService.getByKey(key);
+        Customer currentUser = authenticationService.getCurrentCustomer();
+        if (!salesService.hasAccessToEvent(currentUser, event)) {
+            redirect.addFlashAttribute("error", "You do not have access to this event.");
+
+            return ERROR_REDIRECT;
+        }
+
         List<Order> orders = salesService.getAllOrdersByEvent(event).stream().peek((Order order) -> {
             order.setOwner(null);
             order.setChPaymentsReference(null);

--- a/src/main/java/ch/wisv/events/sales/service/SalesService.java
+++ b/src/main/java/ch/wisv/events/sales/service/SalesService.java
@@ -26,6 +26,15 @@ public interface SalesService {
     List<Product> getAllGrantedProductByCustomer(Customer customer);
 
     /**
+     * Check whether the given customer can access data for a specific event.
+     *
+     * @param customer of type Customer
+     * @param event    of type Event
+     * @return true when the customer is admin or is in the event organizer LDAP group
+     */
+    boolean hasAccessToEvent(Customer customer, Event event);
+
+    /**
      * Get all orders of an event.
      *
      * @param event of type Event

--- a/src/main/java/ch/wisv/events/sales/service/SalesServiceImpl.java
+++ b/src/main/java/ch/wisv/events/sales/service/SalesServiceImpl.java
@@ -89,6 +89,28 @@ public class SalesServiceImpl implements SalesService {
     }
 
     /**
+     * Check if customer can access the given event.
+     *
+     * @param customer of type Customer
+     * @param event    of type Event
+     * @return true when user is admin or has matching LDAP group
+     */
+    @Override
+    public boolean hasAccessToEvent(Customer customer, Event event) {
+        if (event == null) {
+            return false;
+        }
+
+        if (this.currentUserHasAdminRole()) {
+            return true;
+        }
+
+        return customer != null
+                && customer.getLdapGroups() != null
+                && customer.getLdapGroups().contains(event.getOrganizedBy());
+    }
+
+    /**
      * Get all orders associated with the given event.
      *
      * @param event of type Event

--- a/src/main/java/ch/wisv/events/sales/service/SalesServiceImpl.java
+++ b/src/main/java/ch/wisv/events/sales/service/SalesServiceImpl.java
@@ -2,16 +2,20 @@ package ch.wisv.events.sales.service;
 
 import ch.wisv.events.core.model.customer.Customer;
 import ch.wisv.events.core.model.event.Event;
+import ch.wisv.events.core.model.event.EventStatus;
 import ch.wisv.events.core.model.order.Order;
 import ch.wisv.events.core.model.product.Product;
-import ch.wisv.events.core.service.event.EventService;
+import ch.wisv.events.core.repository.EventRepository;
 import ch.wisv.events.core.service.order.OrderService;
-import ch.wisv.events.utils.LdapGroup;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -21,25 +25,29 @@ import java.util.stream.Collectors;
 @Service
 public class SalesServiceImpl implements SalesService {
 
-    /**
-     * EventService.
-     */
-    private final EventService eventService;
+    /** EventRepository. */
+    private final EventRepository eventRepository;
 
     /**
      * OrderService.
      */
     private final OrderService orderService;
 
+    /** Event statuses visible in sales views. */
+    private static final List<EventStatus> SALES_VISIBLE_STATUSES = List.of(
+            EventStatus.PUBLISHED,
+            EventStatus.NOT_PUBLISHED
+    );
+
     /**
      * Default constructor.
      *
-     * @param eventService of type EventService.
+     * @param eventRepository of type EventRepository.
      * @param orderService of type OrderService.
      */
     @Autowired
-    public SalesServiceImpl(EventService eventService, OrderService orderService) {
-        this.eventService = eventService;
+    public SalesServiceImpl(EventRepository eventRepository, OrderService orderService) {
+        this.eventRepository = eventRepository;
         this.orderService = orderService;
     }
 
@@ -50,13 +58,20 @@ public class SalesServiceImpl implements SalesService {
      */
     @Override
     public List<Event> getAllGrantedEventByCustomer(Customer customer) {
-        if (customer.getLdapGroups().contains(LdapGroup.BESTUUR) || customer.getLdapGroups().contains(LdapGroup.BEHEER)) {
-            return eventService.getUpcoming();
-        } else {
-            return eventService.getUpcoming().stream()
-                .filter(events -> customer.getLdapGroups().contains(events.getOrganizedBy()))
-                .collect(Collectors.toList());
+        LocalDateTime startOfToday = LocalDate.now().atStartOfDay();
+        if (this.currentUserHasAdminRole()) {
+            return eventRepository.findAllSalesVisibleEvents(startOfToday, SALES_VISIBLE_STATUSES);
         }
+
+        if (customer == null || customer.getLdapGroups() == null || customer.getLdapGroups().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return eventRepository.findAllSalesVisibleEventsByOrganizedByIn(
+                startOfToday,
+                SALES_VISIBLE_STATUSES,
+                customer.getLdapGroups()
+        );
     }
 
     /**
@@ -86,5 +101,20 @@ public class SalesServiceImpl implements SalesService {
         event.getProducts().stream().forEach(product -> ordersAssociatedWithEvent.addAll(orderService.getAllByProduct(product)));
 
         return ordersAssociatedWithEvent;
+    }
+
+    /**
+     * Check if current authenticated user has admin role.
+     *
+     * @return true if current user has ROLE_ADMIN, false otherwise
+     */
+    private boolean currentUserHasAdminRole() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            return false;
+        }
+
+        return authentication.getAuthorities().stream()
+                .anyMatch(authority -> "ROLE_ADMIN".equals(authority.getAuthority()));
     }
 }

--- a/src/main/resources/templates/sales/index.html
+++ b/src/main/resources/templates/sales/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -43,12 +43,12 @@
                 </div>
                 <div class="col-12">
                     <div class="row justify-content-between">
-                        <!-- <div class="col-4 text-center"> This feature does not work yet, can be added back when fixed
+                        <div class="col-4 text-center" sec:authorize="hasRole('ADMIN')">
                             <a th:href="@{/sales/sell}">
                                 <i class="fa fa-ticket-alt fa-fw fa-4x"></i>
                                 <p>Sell tickets</p>
                             </a>
-                        </div> -->
+                        </div>
                         <div class="col-4 text-center">
                             <a th:href="@{/sales/stats}">
                                 <i class="fas fa-coins fa-fw fa-4x"></i>

--- a/src/main/resources/templates/sales/sell/customer/create.html
+++ b/src/main/resources/templates/sales/sell/customer/create.html
@@ -37,7 +37,7 @@
             <div th:replace="~{fragments/messages :: messages}"></div>
 
             <!--/*@thymesVar id="customer" type="ch.wisv.events.core.model.customer.Customer"*/-->
-            <form th:action="@{'/sales/sell/customer/' + ${order.getPublicReference()}}" th:object="${customer}"
+            <form th:action="@{'/sales/sell/customer/' + ${order.getPublicReference()} + '/create'}" th:object="${customer}"
                   method="POST" class="w-100">
                 <div class="row">
                     <div class="col-12">

--- a/src/main/resources/templates/sales/stats/products/index.html
+++ b/src/main/resources/templates/sales/stats/products/index.html
@@ -55,7 +55,7 @@
                                             <div class="progress mb-2">
                                                 <div class="progress-bar" role="progressbar" aria-valuemin="0"
                                                      aria-valuemax="100"
-                                                     th:style="'width: ' + ${((product.getSold() * 1.0) / (product.getMaxSold() * 1.0)) * 100.0} + '%'">
+                                                     th:style="'width: ' + ${product.getMaxSold() != null && product.getMaxSold() > 0 ? ((product.getSold() * 1.0) / (product.getMaxSold() * 1.0)) * 100.0 : 0.0} + '%'">
                                                 </div>
                                             </div>
                                         </div>

--- a/src/test/java/ch/wisv/events/ControllerTest.java
+++ b/src/test/java/ch/wisv/events/ControllerTest.java
@@ -135,6 +135,7 @@ public abstract class ControllerTest {
         event.setTarget(100);
         event.setDescription("description");
         event.setShortDescription("short description");
+        event.setOrganizedBy(LdapGroup.BEHEER);
 
         eventRepository.saveAndFlush(event);
 

--- a/src/test/java/ch/wisv/events/core/EventRepositoryTest.java
+++ b/src/test/java/ch/wisv/events/core/EventRepositoryTest.java
@@ -1,0 +1,230 @@
+package ch.wisv.events.core;
+
+import ch.wisv.events.core.model.event.Event;
+import ch.wisv.events.core.model.event.EventCategory;
+import ch.wisv.events.core.model.event.EventStatus;
+import ch.wisv.events.core.repository.EventRepository;
+import ch.wisv.events.utils.LdapGroup;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@ActiveProfiles("test")
+@TestPropertySource(properties = "spring.flyway.enabled=false")
+public class EventRepositoryTest {
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Test
+    public void testFindAllSalesVisibleEventsIncludesPublishedStatus() {
+        LocalDateTime startOfToday = LocalDate.now().atStartOfDay();
+
+        Event event = createEvent(
+                "Published event",
+                startOfToday.plusHours(1),
+                startOfToday.plusHours(2),
+                EventStatus.PUBLISHED,
+                LdapGroup.WIFI
+        );
+        eventRepository.saveAndFlush(event);
+
+        List<Event> result = findSalesVisibleEvents(startOfToday);
+
+        assertEquals(1, result.size());
+        assertEquals("Published event", result.get(0).getTitle());
+    }
+
+    @Test
+    public void testFindAllSalesVisibleEventsIncludesNotPublishedStatus() {
+        LocalDateTime startOfToday = LocalDate.now().atStartOfDay();
+
+        Event event = createEvent(
+                "Not published event",
+                startOfToday.plusHours(1),
+                startOfToday.plusHours(2),
+                EventStatus.NOT_PUBLISHED,
+                LdapGroup.WIFI
+        );
+        eventRepository.saveAndFlush(event);
+
+        List<Event> result = findSalesVisibleEvents(startOfToday);
+
+        assertEquals(1, result.size());
+        assertEquals("Not published event", result.get(0).getTitle());
+    }
+
+    @Test
+    public void testFindAllSalesVisibleEventsExcludesConceptStatus() {
+        LocalDateTime startOfToday = LocalDate.now().atStartOfDay();
+
+        Event event = createEvent(
+                "Concept event",
+                startOfToday.plusHours(1),
+                startOfToday.plusHours(2),
+                EventStatus.CONCEPT,
+                LdapGroup.WIFI
+        );
+        eventRepository.saveAndFlush(event);
+
+        List<Event> result = findSalesVisibleEvents(startOfToday);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testFindAllSalesVisibleEventsRespectsEndingBoundaryAtStartOfDay() {
+        LocalDateTime startOfToday = LocalDate.now().atStartOfDay();
+
+        Event includedBoundary = createEvent(
+                "Boundary included",
+                startOfToday.plusHours(1),
+                startOfToday,
+                EventStatus.PUBLISHED,
+                LdapGroup.WIFI
+        );
+        Event excludedBeforeBoundary = createEvent(
+                "Boundary excluded",
+                startOfToday.plusHours(2),
+                startOfToday.minusSeconds(1),
+                EventStatus.PUBLISHED,
+                LdapGroup.WIFI
+        );
+        eventRepository.saveAllAndFlush(List.of(includedBoundary, excludedBeforeBoundary));
+
+        List<Event> result = findSalesVisibleEvents(startOfToday);
+
+        assertEquals(1, result.size());
+        assertEquals("Boundary included", result.get(0).getTitle());
+    }
+
+    @Test
+    public void testFindAllSalesVisibleEventsOrdersByStartAscending() {
+        LocalDateTime startOfToday = LocalDate.now().atStartOfDay();
+
+        Event later = createEvent(
+                "Later",
+                startOfToday.plusHours(3),
+                startOfToday.plusDays(1),
+                EventStatus.PUBLISHED,
+                LdapGroup.WIFI
+        );
+        Event earlier = createEvent(
+                "Earlier",
+                startOfToday.plusHours(1),
+                startOfToday.plusDays(1),
+                EventStatus.NOT_PUBLISHED,
+                LdapGroup.BT
+        );
+        eventRepository.saveAllAndFlush(List.of(later, earlier));
+
+        List<Event> result = findSalesVisibleEvents(startOfToday);
+
+        assertEquals(2, result.size());
+        assertEquals("Earlier", result.get(0).getTitle());
+        assertEquals("Later", result.get(1).getTitle());
+    }
+
+    @Test
+    public void testFindAllSalesVisibleEventsByOrganizedByInIncludesOnlyConfiguredGroups() {
+        LocalDateTime startOfToday = LocalDate.now().atStartOfDay();
+
+        Event included = createEvent(
+                "Included wifi",
+                startOfToday.plusHours(2),
+                startOfToday.plusDays(1),
+                EventStatus.PUBLISHED,
+                LdapGroup.WIFI
+        );
+        Event excludedOtherGroup = createEvent(
+                "Excluded other group",
+                startOfToday.plusHours(3),
+                startOfToday.plusDays(1),
+                EventStatus.PUBLISHED,
+                LdapGroup.BT
+        );
+        eventRepository.saveAllAndFlush(List.of(included, excludedOtherGroup));
+
+        List<Event> result = findSalesVisibleEventsForGroups(startOfToday, List.of(LdapGroup.WIFI));
+
+        assertEquals(1, result.size());
+        assertEquals("Included wifi", result.get(0).getTitle());
+    }
+
+    @Test
+    public void testFindAllSalesVisibleEventsByOrganizedByInStillAppliesStatusAndEndingFilters() {
+        LocalDateTime startOfToday = LocalDate.now().atStartOfDay();
+
+        Event excludedConcept = createEvent(
+                "Excluded concept wifi",
+                startOfToday.plusHours(1),
+                startOfToday.plusDays(1),
+                EventStatus.CONCEPT,
+                LdapGroup.WIFI
+        );
+        Event excludedOld = createEvent(
+                "Excluded old wifi",
+                startOfToday.plusHours(2),
+                startOfToday.minusSeconds(1),
+                EventStatus.PUBLISHED,
+                LdapGroup.WIFI
+        );
+        eventRepository.saveAllAndFlush(List.of(excludedConcept, excludedOld));
+
+        List<Event> result = findSalesVisibleEventsForGroups(startOfToday, List.of(LdapGroup.WIFI));
+
+        assertFalse(result.stream().anyMatch(event -> event.getTitle().equals("Excluded concept wifi")));
+        assertFalse(result.stream().anyMatch(event -> event.getTitle().equals("Excluded old wifi")));
+        assertTrue(result.isEmpty());
+    }
+
+    private List<Event> findSalesVisibleEvents(LocalDateTime from) {
+        return eventRepository.findAllSalesVisibleEvents(
+                from,
+                List.of(EventStatus.PUBLISHED, EventStatus.NOT_PUBLISHED)
+        );
+    }
+
+    private List<Event> findSalesVisibleEventsForGroups(LocalDateTime from, List<LdapGroup> groups) {
+        return eventRepository.findAllSalesVisibleEventsByOrganizedByIn(
+                from,
+                List.of(EventStatus.PUBLISHED, EventStatus.NOT_PUBLISHED),
+                groups
+        );
+    }
+
+    private Event createEvent(
+            String title,
+            LocalDateTime start,
+            LocalDateTime ending,
+            EventStatus status,
+            LdapGroup organizedBy
+    ) {
+        Event event = new Event();
+        event.setTitle(title);
+        event.setShortDescription("Short " + title);
+        event.setDescription("Description " + title);
+        event.setLocation("Delft");
+        event.setStart(start);
+        event.setEnding(ending);
+        event.setTarget(10);
+        event.setPublished(status);
+        event.setOrganizedBy(organizedBy);
+        event.setCategories(List.of(EventCategory.SOCIAL));
+        return event;
+    }
+}

--- a/src/test/java/ch/wisv/events/core/EventRepositoryTest.java
+++ b/src/test/java/ch/wisv/events/core/EventRepositoryTest.java
@@ -8,6 +8,7 @@ import ch.wisv.events.utils.LdapGroup;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -23,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringRunner.class)
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("test")
 @TestPropertySource(properties = "spring.flyway.enabled=false")
 public class EventRepositoryTest {

--- a/src/test/java/ch/wisv/events/sales/service/SalesServiceTest.java
+++ b/src/test/java/ch/wisv/events/sales/service/SalesServiceTest.java
@@ -231,4 +231,52 @@ public class SalesServiceTest extends ServiceTest {
         assertEquals(orders, returnedOrders);
     }
 
+    @Test
+    public void testHasAccessToEventAsAdminRole() {
+        Customer customer = mock(Customer.class);
+        Event event = mock(Event.class);
+        when(event.getOrganizedBy()).thenReturn(LdapGroup.BT);
+        when(customer.getLdapGroups()).thenReturn(List.of(LdapGroup.WIFI));
+
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
+                "admin",
+                "n/a",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_ADMIN"))
+        ));
+
+        assertTrue(salesService.hasAccessToEvent(customer, event));
+    }
+
+    @Test
+    public void testHasAccessToEventAsGroupMember() {
+        Customer customer = mock(Customer.class);
+        Event event = mock(Event.class);
+        when(event.getOrganizedBy()).thenReturn(LdapGroup.WIFI);
+        when(customer.getLdapGroups()).thenReturn(List.of(LdapGroup.WIFI));
+
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
+                "user",
+                "n/a",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+        ));
+
+        assertTrue(salesService.hasAccessToEvent(customer, event));
+    }
+
+    @Test
+    public void testHasAccessToEventDeniedForNonMatchingGroup() {
+        Customer customer = mock(Customer.class);
+        Event event = mock(Event.class);
+        when(event.getOrganizedBy()).thenReturn(LdapGroup.WIFI);
+        when(customer.getLdapGroups()).thenReturn(List.of(LdapGroup.BT));
+
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
+                "user",
+                "n/a",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+        ));
+
+        assertFalse(salesService.hasAccessToEvent(customer, event));
+    }
+
 }

--- a/src/test/java/ch/wisv/events/sales/service/SalesServiceTest.java
+++ b/src/test/java/ch/wisv/events/sales/service/SalesServiceTest.java
@@ -6,16 +6,20 @@ import ch.wisv.events.core.model.customer.Customer;
 import ch.wisv.events.core.model.event.Event;
 import ch.wisv.events.core.model.order.*;
 import ch.wisv.events.core.model.product.Product;
-import ch.wisv.events.core.service.event.EventService;
+import ch.wisv.events.core.repository.EventRepository;
 import ch.wisv.events.core.service.order.OrderService;
 import ch.wisv.events.utils.LdapGroup;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.*;
@@ -27,7 +31,7 @@ public class SalesServiceTest extends ServiceTest {
      * EventService.
      */
     @Mock
-    private EventService eventService;
+    private EventRepository eventRepository;
 
     /**
      * OrderService.
@@ -60,7 +64,7 @@ public class SalesServiceTest extends ServiceTest {
      */
     @Before
     public void setUp() {
-        salesService = new SalesServiceImpl(eventService, orderService);
+        salesService = new SalesServiceImpl(eventRepository, orderService);
         product = mock(Product.class);
         event = mock(Event.class);
         order = mock(Order.class);
@@ -75,27 +79,35 @@ public class SalesServiceTest extends ServiceTest {
         event = null;
         product = null;
         order = null;
+        SecurityContextHolder.clearContext();
     }
 
     /**
      * Test the get all granted events by customer method with a customer in the LDAP group bestuur
      */
     @Test
-    public void testGetAllGrantedEventByCustomerAsBestuur() {
+    public void testGetAllGrantedEventByCustomerAsAdminRole() {
         List<Event> events = new ArrayList<>();
         events.add(event);
 
         List<LdapGroup> ldapGroups = new ArrayList<>();
         ldapGroups.add(LdapGroup.BESTUUR);
 
-        when(eventService.getUpcoming()).thenReturn(events);
+        when(eventRepository.findAllSalesVisibleEvents(any(LocalDateTime.class), anyCollection())).thenReturn(events);
 
         Customer customer = mock(Customer.class);
         when(customer.getLdapGroups()).thenReturn(ldapGroups);
 
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
+                "admin",
+                "n/a",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_ADMIN"))
+        ));
+
         List<Event> returnedEvents = salesService.getAllGrantedEventByCustomer(customer);
 
-        verify(eventService, times(1)).getUpcoming();
+        verify(eventRepository, times(1)).findAllSalesVisibleEvents(any(LocalDateTime.class), anyCollection());
+        verify(eventRepository, times(0)).findAllSalesVisibleEventsByOrganizedByIn(any(LocalDateTime.class), anyCollection(), anyCollection());
 
         assertEquals(events, returnedEvents);
     }
@@ -111,15 +123,21 @@ public class SalesServiceTest extends ServiceTest {
         List<LdapGroup> ldapGroups = new ArrayList<>();
         ldapGroups.add(LdapGroup.WIFI);
 
-        when(eventService.getUpcoming()).thenReturn(events);
-        when(event.getOrganizedBy()).thenReturn(LdapGroup.BT);
+        when(eventRepository.findAllSalesVisibleEventsByOrganizedByIn(any(LocalDateTime.class), anyCollection(), anyCollection()))
+                .thenReturn(new ArrayList<>());
 
         Customer customer = mock(Customer.class);
         when(customer.getLdapGroups()).thenReturn(ldapGroups);
 
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
+                "user",
+                "n/a",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+        ));
+
         List<Event> returnedEvents = salesService.getAllGrantedEventByCustomer(customer);
 
-        verify(eventService, times(1)).getUpcoming();
+        verify(eventRepository, times(1)).findAllSalesVisibleEventsByOrganizedByIn(any(LocalDateTime.class), anyCollection(), anyCollection());
 
         assertEquals(0, returnedEvents.size());
     }
@@ -135,15 +153,21 @@ public class SalesServiceTest extends ServiceTest {
         List<LdapGroup> ldapGroups = new ArrayList<>();
         ldapGroups.add(LdapGroup.WIFI);
 
-        when(eventService.getUpcoming()).thenReturn(events);
-        when(event.getOrganizedBy()).thenReturn(LdapGroup.WIFI);
+        when(eventRepository.findAllSalesVisibleEventsByOrganizedByIn(any(LocalDateTime.class), anyCollection(), anyCollection()))
+                .thenReturn(events);
 
         Customer customer = mock(Customer.class);
         when(customer.getLdapGroups()).thenReturn(ldapGroups);
 
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
+                "user",
+                "n/a",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+        ));
+
         List<Event> returnedEvents = salesService.getAllGrantedEventByCustomer(customer);
 
-        verify(eventService, times(1)).getUpcoming();
+        verify(eventRepository, times(1)).findAllSalesVisibleEventsByOrganizedByIn(any(LocalDateTime.class), anyCollection(), anyCollection());
 
         assertEquals(events, returnedEvents);
     }
@@ -162,8 +186,8 @@ public class SalesServiceTest extends ServiceTest {
         List<LdapGroup> ldapGroups = new ArrayList<>();
         ldapGroups.add(LdapGroup.WIFI);
 
-        when(eventService.getUpcoming()).thenReturn(events);
-        when(event.getOrganizedBy()).thenReturn(LdapGroup.WIFI);
+        when(eventRepository.findAllSalesVisibleEventsByOrganizedByIn(any(LocalDateTime.class), anyCollection(), anyCollection()))
+                .thenReturn(events);
         when(event.getProducts()).thenReturn(products);
         when(product.getSellStart()).thenReturn(LocalDateTime.MIN);
         when(product.getSellEnd()).thenReturn(LocalDateTime.MAX);
@@ -171,9 +195,15 @@ public class SalesServiceTest extends ServiceTest {
         Customer customer = mock(Customer.class);
         when(customer.getLdapGroups()).thenReturn(ldapGroups);
 
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
+                "user",
+                "n/a",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+        ));
+
         List<Product> returnedProducts = salesService.getAllGrantedProductByCustomer(customer);
 
-        verify(eventService, times(1)).getUpcoming();
+        verify(eventRepository, times(1)).findAllSalesVisibleEventsByOrganizedByIn(any(LocalDateTime.class), anyCollection(), anyCollection());
 
         assertEquals(products, returnedProducts);
     }


### PR DESCRIPTION
- Sell is now admin-only:
  - The Sell button is hidden for non-admins.
  - All `/sales/sell/**` endpoints now require `ROLE_ADMIN`.
  - Reason: only admins should be able to sell.

- Event filtering for sales was updated and made faster:
  - Uses DB queries instead of filtering in Java to make the page load faster .
  - Admin is now based on role (`ROLE_ADMIN`), not hardcoded LDAP groups.
  - Non-admin users only see events from their own LDAP groups.
  - “Upcoming” now includes `PUBLISHED` and `NOT_PUBLISHED`, per request of the board.

- Fixed security hole on direct scan/stats links:
  - Added an extra check on event pages and APIs:
    - user must be admin, or
    - user must be in the event’s organizer group.
  - Applied to scan page, scan API, and stats event/products pages.

- Fixed customer creation in sell flow:
  - Create form now posts to the correct `/create` endpoint.
  - Fixed redirect after create to the correct sell order page.