### PR TITLE
Clarify cancelled payment page and handle CHPay CANCELLED status

### DIFF
--- a/src/main/java/ch/wisv/events/webshop/service/PaymentsServiceImpl.java
+++ b/src/main/java/ch/wisv/events/webshop/service/PaymentsServiceImpl.java
@@ -304,7 +304,8 @@ public class PaymentsServiceImpl implements PaymentsService {
     public enum TransactionStatus {
         SUCCESSFUL,
         FAILED,
-        PENDING
+        PENDING,
+        CANCELLED,
     }
 
     private Order updateCHPayOrder(Order order) {
@@ -335,7 +336,7 @@ public class PaymentsServiceImpl implements PaymentsService {
 
             switch (response) {
                 case PENDING -> orderService.updateOrderStatus(order,OrderStatus.PENDING);
-                case FAILED -> orderService.updateOrderStatus(order,OrderStatus.CANCELLED);
+                case FAILED, CANCELLED -> orderService.updateOrderStatus(order,OrderStatus.CANCELLED);
                 case SUCCESSFUL -> orderService.updateOrderStatus(order,OrderStatus.PAID);
                 default -> orderService.updateOrderStatus(order,order.getStatus());
             }

--- a/src/main/resources/templates/webshop/return/cancelled.html
+++ b/src/main/resources/templates/webshop/return/cancelled.html
@@ -34,7 +34,7 @@
 
 <body>
 <nav
-        th:replace="~{webshop/fragments/header :: header ('Order has been cancelled!', 'events_order-cancelled-owl.jpg')}"></nav>
+        th:replace="~{webshop/fragments/header :: header ('Payment cancelled', 'events_order-cancelled-owl.jpg')}"></nav>
 
 <div class="container">
     <div class="row">
@@ -43,14 +43,15 @@
 
             <div class="row">
                 <div class="col my-4">
-                    <h4 class="display-4">Order has been cancelled!</h4>
+                    <h4 class="display-4">Payment cancelled</h4>
                 </div>
             </div>
             <div class="row justify-content-center mb-5">
                 <div class="col-12">
-                    <p class="text-justify">Your order has been cancelled. If you want to try it again the
-                        payment again, click on the 'Try payment again' button. Otherwise click on the
-                        'Back to the homepage' to go back to the homepage.
+                    <p class="text-justify">
+                        Your payment was cancelled before completion, so this order was not paid.
+                        You can retry and select a different payment method using the button below,
+                        or return to the homepage.
                     </p>
                 </div>
             </div>
@@ -64,7 +65,7 @@
                 </div>
                 <div class="col-auto">
                     <a th:href="@{'/checkout/' + ${order.getPublicReference()} + '/payment'}" class="btn btn-info">
-                        Try payment again
+                        Retry payment
                         <i class="fas fa-fw fa-sync"></i>
                     </a>
                 </div>


### PR DESCRIPTION
I see many people at events choosing CHpay, then redoing the order with iDeal after deciding they didn't want to use CHpay. I am building a cancelled payment feature in CHpay, and this PR updates events to use it. It also makes the description on the cancelled page clearer.

## Summary
- clarify cancelled return page copy to describe cancelled payment explicitly
- mention users can retry and choose a different payment method
- map CHPay CANCELLED transaction status to internal CANCELLED order status

## Files
- src/main/resources/templates/webshop/return/cancelled.html
- src/main/java/ch/wisv/events/webshop/service/PaymentsServiceImpl.java