### PR TITLE
Add direct Cloud Logging for Events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,15 +36,13 @@ repositories {
 configurations {
     // We're using HikariCP instead
     implementation.exclude module: "tomcat-jdbc"
-
-    // We're using Log4j2 instead
-    implementation.exclude module: "spring-boot-starter-logging"
 }
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-devtools'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+    implementation platform('com.google.cloud:libraries-bom:26.85.0')
+    implementation 'com.google.cloud:google-cloud-logging-logback'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-tomcat'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,29 @@
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <springProfile name="!production">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE" />
+        </root>
+    </springProfile>
+
+    <springProfile name="production">
+        <!-- Write structured entries directly to Cloud Logging via Workload Identity. -->
+        <appender name="GOOGLE_CLOUD" class="com.google.cloud.logging.logback.LoggingAppender">
+            <log>application/events</log>
+            <resourceType>k8s_container</resourceType>
+            <flushLevel>ERROR</flushLevel>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE" />
+            <appender-ref ref="GOOGLE_CLOUD" />
+        </root>
+    </springProfile>
+
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -15,7 +15,7 @@
     <springProfile name="production">
         <!-- Write structured entries directly to Cloud Logging via Workload Identity. -->
         <appender name="GOOGLE_CLOUD" class="com.google.cloud.logging.logback.LoggingAppender">
-            <log>application/events</log>
+            <log>application.events</log>
             <resourceType>k8s_container</resourceType>
             <flushLevel>ERROR</flushLevel>
         </appender>


### PR DESCRIPTION
Send Events production logs directly to Cloud Logging as application/events while retaining console logs.

This is in response to events crashing, and us not saving logs.